### PR TITLE
fix name resolution of allowed hosts

### DIFF
--- a/pkg/snclient/allowed_host.go
+++ b/pkg/snclient/allowed_host.go
@@ -94,7 +94,7 @@ func (a *AllowedHost) resolveCache() []netip.Addr {
 
 	for _, v := range ips {
 		i, err := netip.ParseAddr(v.String())
-		if err != nil {
+		if err == nil {
 			resolved = append(resolved, i)
 		}
 	}


### PR DESCRIPTION
just replaced err != nil by err == nil, which means that a hostname could be resolved to a valid ip address and should be cached.