### PR TITLE
wrap an error in check_service_linux

### DIFF
--- a/pkg/snclient/check_service_linux.go
+++ b/pkg/snclient/check_service_linux.go
@@ -63,7 +63,7 @@ func (l *CheckService) Check(snc *Agent, args []string) (*CheckResult, error) {
 		if err != nil {
 			return &CheckResult{
 				State:  CheckExitUnknown,
-				Output: fmt.Sprintf("Failed to fetch service list: %s%s", err, stderr),
+				Output: fmt.Sprintf("Failed to fetch service list: %s%s", err.Error(), stderr),
 			}, nil
 		}
 

--- a/pkg/snclient/check_service_linux_test.go
+++ b/pkg/snclient/check_service_linux_test.go
@@ -8,7 +8,16 @@ import (
 )
 
 func TestCheckServiceLinux(t *testing.T) {
-	snc := Agent{}
+	flags := &AgentFlags{
+		Quiet: true,
+	}
+	snc := NewAgent(flags)
+
+	initSet, _ := snc.Init()
+	snc.initSet = initSet
+	snc.Tasks = initSet.tasks
+	snc.Config = initSet.config
+
 	res := snc.RunCheck("check_service", []string{"filter='state=running'"})
 	assert.Equalf(t, CheckExitOK, res.State, "state OK")
 	assert.Regexpf(t,


### PR DESCRIPTION
(test case needs a config because of possible future changes in executing external commands)