### PR TITLE
when executing an external command, set the working dir to the scripts folder

### DIFF
--- a/pkg/snclient/check_wrap_unix_test.go
+++ b/pkg/snclient/check_wrap_unix_test.go
@@ -30,6 +30,7 @@ exe = %%SCRIPT%% %%ARGS%%
 timeout = 1111111
 [/settings/external scripts/scripts]
 check_doesnotexist = /a/path/that/does/not/exist/nonexisting_script "no" "no"
+check_cwd = cat pluginoutput
 
 check_dummy = check_dummy.EXTENSION
 check_dummy_ok = check_dummy.EXTENSION 0 "i am ok"
@@ -78,6 +79,20 @@ func TestMain(m *testing.M) {
 
 	// exit with the same exit code as the tests
 	os.Exit(exitCode)
+}
+
+func TestCheckExternalUnixCwd(t *testing.T) {
+	testDir, _ := os.Getwd()
+	scriptsDir := filepath.Join(testDir, "t", "scripts")
+
+	config := setupConfig(scriptsDir, "sh")
+	snc := StartTestAgent(t, config)
+
+	res := snc.RunCheck("check_cwd", []string{})
+	assert.Equalf(t, CheckExitOK, res.State, "state matches")
+	assert.Equalf(t, "i am in the scripts folder", string(res.BuildPluginOutput()), "output matches")
+
+	StopTestAgent(t, snc)
 }
 
 func TestCheckExternalUnixTimeout(t *testing.T) {

--- a/pkg/snclient/check_wrap_windows_test.go
+++ b/pkg/snclient/check_wrap_windows_test.go
@@ -27,6 +27,7 @@ exe = %%SCRIPT%% %%ARGS%%
 
 [/settings/external scripts/scripts]
 check_doesnotexist = /a/path/that/does/not/exist/nonexisting_script "no" "no"
+check_cwd = type pluginoutput
 
 check_dummy = check_dummy.EXTENSION
 check_dummy_ok = check_dummy.EXTENSION 0 "i am ok"
@@ -70,6 +71,20 @@ func TestMain(m *testing.M) {
 
 	// exit with the same exit code as the tests
 	os.Exit(exitCode)
+}
+
+unc TestCheckExternalWindowsCwd(t *testing.T) {
+        testDir, _ := os.Getwd()
+        scriptsDir := filepath.Join(testDir, "t", "scripts")
+
+        config := setupConfig(scriptsDir, "sh")
+        snc := StartTestAgent(t, config)
+
+        res := snc.RunCheck("check_cwd", []string{})
+        assert.Equalf(t, CheckExitOK, res.State, "state matches")
+        assert.Equalf(t, "i am in the scripts folder", string(res.BuildPluginOutput()), "output matches")
+
+        StopTestAgent(t, snc)
 }
 
 func TestCheckExternalWindowsTimeout(t *testing.T) {

--- a/pkg/snclient/check_wrap_windows_test.go
+++ b/pkg/snclient/check_wrap_windows_test.go
@@ -73,18 +73,18 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-unc TestCheckExternalWindowsCwd(t *testing.T) {
-        testDir, _ := os.Getwd()
-        scriptsDir := filepath.Join(testDir, "t", "scripts")
+func TestCheckExternalWindowsCwd(t *testing.T) {
+	testDir, _ := os.Getwd()
+	scriptsDir := filepath.Join(testDir, "t", "scripts")
 
-        config := setupConfig(scriptsDir, "sh")
-        snc := StartTestAgent(t, config)
+	config := setupConfig(scriptsDir, "sh")
+	snc := StartTestAgent(t, config)
 
-        res := snc.RunCheck("check_cwd", []string{})
-        assert.Equalf(t, CheckExitOK, res.State, "state matches")
-        assert.Equalf(t, "i am in the scripts folder", string(res.BuildPluginOutput()), "output matches")
+	res := snc.RunCheck("check_cwd", []string{})
+	assert.Equalf(t, CheckExitOK, res.State, "state matches")
+	assert.Equalf(t, "i am in the scripts folder", string(res.BuildPluginOutput()), "output matches")
 
-        StopTestAgent(t, snc)
+	StopTestAgent(t, snc)
 }
 
 func TestCheckExternalWindowsTimeout(t *testing.T) {

--- a/pkg/snclient/check_wrap_windows_test.go
+++ b/pkg/snclient/check_wrap_windows_test.go
@@ -27,7 +27,7 @@ exe = %%SCRIPT%% %%ARGS%%
 
 [/settings/external scripts/scripts]
 check_doesnotexist = /a/path/that/does/not/exist/nonexisting_script "no" "no"
-check_cwd = type pluginoutput
+check_cwd = cmd /c type pluginoutput
 
 check_dummy = check_dummy.EXTENSION
 check_dummy_ok = check_dummy.EXTENSION 0 "i am ok"

--- a/pkg/snclient/snclient.go
+++ b/pkg/snclient/snclient.go
@@ -1142,7 +1142,7 @@ func MakeCmd(ctx context.Context, command, scriptsPath string) (*exec.Cmd, error
 		command = strings.Replace(command, cmdPath, strings.ReplaceAll(cmdPathReplacement, " ", "__SNCLIENT_BLANK__"), 1)
 	}
 
-	cmd, err := makeCmd(ctx, command)
+	cmd, err := makeCmd(ctx, command, scriptsPath)
 	if cmd.Args != nil {
 		log.Tracef("command object:\n path: %s\n args: %v\n SysProcAttr: %v\n", cmd.Path, cmd.Args, cmd.SysProcAttr)
 	} else {

--- a/pkg/snclient/snclient_unix.go
+++ b/pkg/snclient/snclient_unix.go
@@ -108,10 +108,11 @@ func processTimeoutKill(process *os.Process) {
 	}(process.Pid)
 }
 
-func makeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
+func makeCmd(ctx context.Context, command, workingDir string) (*exec.Cmd, error) {
 	command = strings.ReplaceAll(command, "__SNCLIENT_BLANK__", "\\ ")
 	cmdList := []string{"/bin/sh", "-c", command}
 	cmd := exec.CommandContext(ctx, cmdList[0], cmdList[1:]...) // #nosec G204
+	cmd.Dir = workingDir
 	// prevent child from receiving signals meant for the agent only
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,

--- a/pkg/snclient/snclient_windows.go
+++ b/pkg/snclient/snclient_windows.go
@@ -193,7 +193,7 @@ func processTimeoutKill(process *os.Process) {
 	LogDebug(process.Signal(syscall.SIGKILL))
 }
 
-func makeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
+func makeCmd(ctx context.Context, command, workingDir string) (*exec.Cmd, error) {
 	if strings.Contains(command, "LASTEXITCODE") || strings.Contains(command, "lastexitcode") {
 		// This is a hack. Without it, neither syscallCommandLineToArgv nor Tokenize will
 		// properly parse ...check_sometjing.ps1 "para meter"; exit($LASTEXITCODE)...
@@ -222,6 +222,7 @@ func makeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 			cmdArgs[i] = syscall.EscapeArg(ca)
 		}
 		cmd := exec.CommandContext(ctx, shell, "")
+		cmd.Dir = workingDir
 		cmd.Args = nil
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			HideWindow: true,
@@ -236,6 +237,7 @@ func makeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 		}
 		cmdName = strings.ReplaceAll(cmdName, "__SNCLIENT_BLANK__", " ")
 		cmd := exec.CommandContext(ctx, "powershell")
+		cmd.Dir = workingDir
 		cmd.Args = nil
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			HideWindow: true,
@@ -250,6 +252,7 @@ func makeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 		cmdArgs[i] = strings.ReplaceAll(ca, "__SNCLIENT_BLANK__", " ")
 	}
 	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
+	cmd.Dir = workingDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow: true,
 	}
@@ -275,7 +278,6 @@ func makeCmdNoParams(ctx context.Context, cmdName string) (*exec.Cmd, error) {
 
 	return cmd, nil
 }
-
 func isBatchFile(path string) bool {
 	ext := filepath.Ext(path)
 

--- a/pkg/snclient/t/scripts/pluginoutput
+++ b/pkg/snclient/t/scripts/pluginoutput
@@ -1,0 +1,1 @@
+i am in the scripts folder


### PR DESCRIPTION
use os.Command's Dir attribute to run external commands in the scripts folder (a config setting)