### PR TITLE
Allow monitoring of Windows services as non-Admin

### DIFF
--- a/pkg/snclient/check_service_windows.go
+++ b/pkg/snclient/check_service_windows.go
@@ -69,9 +69,19 @@ func (l *CheckService) Build() *CheckData {
 	}
 }
 
+// MgrConnectReadOnly establishes a read-only connection to the 
+// local service control manager.
+func MgrConnectReadOnly() (*mgr.Mgr, error) { 
+	h, err := windows.OpenSCManager(nil, nil, windows.GENERIC_READ) 
+	if err != nil { 
+		return nil, err 
+	} 
+	return &mgr.Mgr{Handle: h}, nil 
+} 
+
 func (l *CheckService) Check(_ context.Context, _ *Agent, check *CheckData, _ []Argument) (*CheckResult, error) {
 	// collect service state
-	ctrlMgr, err := mgr.Connect()
+	ctrlMgr, err := MgrConnectReadOnly()
 	if err != nil {
 		return &CheckResult{
 			State:  int64(3),


### PR DESCRIPTION
Opening a connection to the Service Control Manager with read-only access allows us to run snclient as non-privileged user and check the status of Windows services.