### PR TITLE
Update task_check_system.go

### DIFF
--- a/pkg/snclient/task_check_system.go
+++ b/pkg/snclient/task_check_system.go
@@ -107,15 +107,8 @@ func (c *CheckSystemHandler) update(create bool) {
 		}
 		c.snc.Counter.Set("net", key, val)
 
-		// clean old interfaces
-		for _, key := range c.snc.Counter.Keys("net") {
-			counter := c.snc.Counter.Get("net", key)
-			if last := counter.GetLast(); last != nil {
-				if last.timestamp.Before(trimData) {
-					c.snc.Counter.Delete("net", key)
-				}
-			}
-		}
+		// clean old values
+		c.snc.Counter.Get("net", key).Trim()
 	}
 }
 


### PR DESCRIPTION
Do not delete interface but old values only using useful Trim function.

Otherwise got nil pointer dereference.

[2023-11-26 17:12:22.461][Error][pid:538522][snclient:671] Panic: runtime error: invalid memory address or nil pointer dereference [2023-11-26 17:12:22.461][Error][pid:538522][snclient:672] **** Stack: [2023-11-26 17:12:22.461][Error][pid:538522][snclient:673] goroutine 14 [running]: runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x5e
pkg/snclient.(*Agent).logPanicRecover(0x0?)
	pkg/snclient@v0.0.0-00010101000000-000000000000/snclient.go:673 +0x168
panic({0xb3cc40?, 0x11b5da0?})
	runtime/panic.go:914 +0x21f
pkg/snclient.(*Counter).GetLast(...)
	pkg/snclient@v0.0.0-00010101000000-000000000000/counter.go:91
pkg/snclient.(*CheckNetwork).Check(0xc0001ae800, {0xc0000e4930?, 0x1?}, 0x1?, 0xc000014240, {0x1?, 0x1?, 0xc0002bc200?})
	pkg/snclient@v0.0.0-00010101000000-000000000000/check_network.go:107 +0xdb3
pkg/snclient.(*Agent).runCheck(0x50fb0d?, {0xd1c098, 0xc0000e4930}, {0xc0001a94c0, 0xd}, {0xc0002bc1f0, 0x1, 0x1})
	pkg/snclient@v0.0.0-00010101000000-000000000000/snclient.go:727 +0x375
pkg/snclient.(*Agent).RunCheckWithContext(0xd1bf48?, {0xd1c098?, 0xc0000e4930?}, {0xc0001a94c0?, 0xc0002bc1f0?}, {0xc0002bc1f0?, 0x0?, 0xc0003fbcb0?})
	pkg/snclient@v0.0.0-00010101000000-000000000000/snclient.go:688 +0x2a
pkg/snclient.(*Agent).RunCheck(0xc00019ab70?, {0xc0001a94c0, 0xd}, {0xc0002bc1f0, 0x1, 0x1})
	pkg/snclient@v0.0.0-00010101000000-000000000000/snclient.go:683 +0xad
pkg/snclient.(*HandlerNRPE).ServeTCP(0xc000196d08, 0x8589ca442?, {0xd20698?, 0xc000157880})
	pkg/snclient@v0.0.0-00010101000000-000000000000/listen_nrpe.go:116 +0x5f4
pkg/snclient.(*Listener).handleTCPCon(0xc0001b0120, {0xd20698, 0xc000157880}, {0x7f12471f8830, 0xc000196d08})
	pkg/snclient@v0.0.0-00010101000000-000000000000/listener.go:336 +0x322
pkg/snclient.(*Listener).startListenerTCP.func1({0xd20698?, 0xc000157880?})
	pkg/snclient@v0.0.0-00010101000000-000000000000/listener.go:316 +0x6b
created by pkg/snclient.(*Listener).startListenerTCP in goroutine 36
	pkg/snclient@v0.0.0-00010101000000-000000000000/listener.go:312 +0x2b6
[2023-11-26 17:12:22.461][Error][pid:538522][snclient:674] *************************