### PR TITLE
Handle managed exporter messages case insensitive

### DIFF
--- a/pkg/snclient/listen_managedexporter.go
+++ b/pkg/snclient/listen_managedexporter.go
@@ -324,11 +324,11 @@ func (l *HandlerManagedExporter) procMemWatcher() {
 func (l *HandlerManagedExporter) logPass(f string, v ...interface{}) {
 	entry := fmt.Sprintf(f, v...)
 	switch {
-	case strings.Contains(entry, "level=warn"):
+	case strings.Contains(strings.ToLower(entry), "level=warn"):
 		log.Warn(entry)
-	case strings.Contains(entry, "level=info"):
+	case strings.Contains(strings.ToLower(entry), "level=info"):
 		log.Debug(entry)
-	case strings.Contains(entry, "level=debug"):
+	case strings.Contains(strings.ToLower(entry), "level=debug"):
 		log.Trace(entry)
 	default:
 		log.Error(entry)


### PR DESCRIPTION
The blackbox_exporter (and possible other exporters as well) outputs the log level in upper case: 
time=2025-03-03T19:58:53.853Z level=INFO source=main.go:86 msg="Starting blackbox_exporter" 
As snclient only matches on "level=info", this message becomes an error message in the snclient.log. 
This commit leaves the original level intact.