### PR TITLE
allow forwardslash in drive and folder

### DIFF
--- a/pkg/snclient/check_drivesize_windows.go
+++ b/pkg/snclient/check_drivesize_windows.go
@@ -414,6 +414,8 @@ func (l *CheckDrivesize) setVolume(requiredDisks map[string]map[string]string, v
 }
 
 func (l *CheckDrivesize) setCustomPath(drive string, requiredDisks map[string]map[string]string, parentFallback bool) (err error) {
+	// Also allow c:/, d:/volume, f:/folder/with/slash
+	drive = strings.ReplaceAll(drive, "/", "\\")
 	// match a drive, ex: "c" or "c:"
 	switch len(drive) {
 	case 1, 2:

--- a/pkg/snclient/check_drivesize_windows_test.go
+++ b/pkg/snclient/check_drivesize_windows_test.go
@@ -60,5 +60,11 @@ func TestCheckDrivesize(t *testing.T) {
 	assert.Contains(t, string(res.BuildPluginOutput()), `OK - All 1 drive`, "output matches")
 	assert.Contains(t, string(res.BuildPluginOutput()), `c:\Windows used %`, "output matches")
 
+	// check with forward slash
+	res = snc.RunCheck("check_drivesize", []string{"warn=used>100%", "crit=used>100%", "folder=c:/Windows"})
+	assert.Equalf(t, CheckExitOK, res.State, "state OK")
+	res = snc.RunCheck("check_drivesize", []string{"warn=used>100%", "crit=used>100%", "drive=c:/"})
+	assert.Equalf(t, CheckExitOK, res.State, "state ok")
+
 	StopTestAgent(t, snc)
 }


### PR DESCRIPTION
nsclient also allowed checking for c:/volume, we do this by just replacing all forward slashes with backslashes.