### PR TITLE
Windows pointer

### DIFF
--- a/pkg/pdh/pdh.go
+++ b/pkg/pdh/pdh.go
@@ -570,11 +570,12 @@ contains the same wildcards as before
 func PdhGetCounterInfo(hConuter PDH_HCOUNTER, retrieveExplainText bool) (string, error) {
 	zz := uint32(0)
 	tr := uint8(1)
+	var fakeBuffer [1]byte
 	if res, _, _ := pdh_PdhGetCounterInfoW.Call(
 		uintptr(hConuter),
 		uintptr(unsafe.Pointer(&tr)),
 		uintptr(unsafe.Pointer(&zz)),
-		uintptr(0),
+		uintptr(unsafe.Pointer(&fakeBuffer[0])),
 	); res != PDH_MORE_DATA {
 		return "", fmt.Errorf("Could not get Counter Info Response Code from Api Call: %d", res)
 	}

--- a/pkg/snclient/check_pdh_test.go
+++ b/pkg/snclient/check_pdh_test.go
@@ -1,3 +1,4 @@
+//run -gcflags=-d=checkptr
 //go:build windows
 // +build windows
 

--- a/pkg/snclient/check_pdh_test.go
+++ b/pkg/snclient/check_pdh_test.go
@@ -1,4 +1,4 @@
-//run -gcflags=-d=checkptr
+// run -gcflags=-d=checkptr
 //go:build windows
 // +build windows
 


### PR DESCRIPTION
Possible Cause of Pipeline Error because of allocation issues 