### PR TITLE
packaging rpm: use non legacy compat action post upgrade

### DIFF
--- a/packaging/snclient.spec
+++ b/packaging/snclient.spec
@@ -64,7 +64,7 @@ case "$*" in
   2)
     # Upgrading
     systemctl --system daemon-reload >/dev/null || true
-    systemctl condrestart snclient.service >/dev/null || true
+    systemctl try-restart snclient.service >/dev/null || true
   ;;
   *) echo case "$*" not handled in post
 esac


### PR DESCRIPTION
Since everything in the specfile is using systemd, there is no need to use the compatibility action `condrestart` but we can actually use the documented `try-restart` action which will yield the same result of restarting the service when it is started or leave it alone if it was not yet started.