### PR TITLE
we should not really create the logfile from the package

### DIFF
--- a/packaging/snclient.spec
+++ b/packaging/snclient.spec
@@ -70,7 +70,6 @@ case "$*" in
 esac
 
 %{__mkdir_p} /var/log/snclient
-touch /var/log/snclient/snclient.log
 
 %preun
 case "$*" in


### PR DESCRIPTION
When starting snclient the logfile will be created.

Context:
We use systemd overrides to run snclient as regular user, for our usecase this works just fine, but on rpm based distro's we still get the `/var/log/snclient/snclient.log` file with root permissions because it is created in the post install of the package.