### PR TITLE
change minimum golang requirement to 1.25.5

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 This file documents the revision history for the SNClient agent.
 
+next
+         - change minimum golang requirement to 1.25.5
+
 0.39     Tue Nov 18 14:22:01 CET 2025
          - optionally send HSTS header in HTTP response
          - update node exporter to 1.10.2

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ GOVERSION:=$(shell \
 )
 # also update docs/install/build.md and .github/workflows/builds.yml when changing minimum version
 # find . -name go.mod (run make gomods afterwards)
-MINGOVERSION:=00010024
-MINGOVERSIONSTR:=1.24
+MINGOVERSION:=00010025
+MINGOVERSIONSTR:=1.25
 BUILD:=$(shell git rev-parse --short HEAD)
 REVISION:=$(shell ./buildtools/get_version | awk -F . '{ print $$3 }')
 # see https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md

--- a/buildtools/go.mod
+++ b/buildtools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.9
+go 1.25.5
 
 require (
 	github.com/daixiang0/gci v0.13.7

--- a/docs/install/build.md
+++ b/docs/install/build.md
@@ -6,7 +6,7 @@ linkTitle: From Source
 
 ## Requirements
 
-- golang >= 1.25.5
+- golang
 - openssl
 - make
 - help2man

--- a/docs/install/build.md
+++ b/docs/install/build.md
@@ -6,7 +6,7 @@ linkTitle: From Source
 
 ## Requirements
 
-- golang >= 1.24
+- golang >= 1.25.5
 - openssl
 - make
 - help2man

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/consol-monitoring/snclient
 
-go 1.24.9
+go 1.25.5
 
 require (
 	github.com/beevik/ntp v1.5.0


### PR DESCRIPTION
Updated to use a new function in standard library: [fs.ReadLink](https://pkg.go.dev/io/fs#ReadLink) . Was going to use it in a feature branch, but it ended up unnecessary.