### PR TITLE
revise external script discovery

### DIFF
--- a/docs/checks/external_commands/_index.md
+++ b/docs/checks/external_commands/_index.md
@@ -110,6 +110,20 @@ restart_service = NET START "$ARG1$"
 
 If your scripts are located within the `${scripts}` folder, you can specify them using relative paths, as demonstrated in the examples. SNClient will automatically obtain the absolute path for these scripts and use it for execution. Prior to running the scripts, SNClient configures the working directory to be ${shared-dir}.
 
+
+#### Script Discovery
+
+```
+; Load all scripts in a given folder - Load all (${script path}/*) scripts in a given directory and use them as commands.
+; Any executable file is considered a script. They do not have end with an script like extension.
+; In windows, executable files cannot be discerned. It will add every file under the directory.
+; Links are followed, and if they end up under script path, they will be added as a script.
+; If path ends with ** its subdirectories will be searched as well.
+script path = ${scripts}/autoinclude
+```
+
+Scripts can also be automatically discovered and added, without defining them individually. This uses the `script path` setting. There is no way to change the alias, as they will use the scripts name and extension for their alias.
+
 #### Wrapped Scripts
 
 Specify script templates used to define script commands. These templates are expanded by scripts located in the Wrapped Scripts section. Use `%SCRIPT%` to represent the actual script and `%ARGS%` for any provided arguments.

--- a/packaging/snclient.ini
+++ b/packaging/snclient.ini
@@ -346,7 +346,11 @@ allow nasty characters = false
 ; Script root folder - Root path where all scripts are contained (You can not upload/download scripts outside this folder).
 script root = ${scripts}
 
-; Load all scripts in a given folder - Load all (${script path}/*.*) scripts in a given directory and use them as commands.
+; Load all scripts in a given folder - Load all (${script path}/*) scripts in a given directory and use them as commands.
+; Any executable file is considered a script. They do not have end with an script like extension.
+; In windows, executable files cannot be discerned. It will add every file under the directory.
+; Links are followed, and if they end up under script path, they will be added as a script.
+; If path ends with ** its subdirectories will be searched as well.
 script path =
 
 ; ignore perfdata - Do not parse performance data from the output

--- a/pkg/snclient/task_external_scripts.go
+++ b/pkg/snclient/task_external_scripts.go
@@ -2,9 +2,12 @@ package snclient
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -66,6 +69,9 @@ func (e *ExternalScriptsHandler) registerScripts(conf *Config, runSet *AgentRunS
 		cmdConf := conf.Section(sectionName)
 		if command, _, ok := cmdConf.GetStringRaw("command"); ok {
 			log.Tracef("registered script: %s -> %s", name, command)
+			if _, ok := AvailableChecks[name]; ok {
+				log.Warnf("there is a built in check with the name: %s . the external script registered on path: %s has the same base name", name, command)
+			}
 			runSet.cmdWraps[name] = CheckEntry{name, func() CheckHandler {
 				return &CheckWrap{name: name, commandString: strings.Join(command, " "), config: cmdConf}
 			}}
@@ -96,6 +102,9 @@ func (e *ExternalScriptsHandler) registerWrapped(conf *Config, runSet *AgentRunS
 		cmdConf := conf.Section(sectionName)
 		if command, _, ok := cmdConf.GetStringRaw("command"); ok {
 			log.Tracef("registered wrapped script: %s -> %s", name, command)
+			if _, ok := AvailableChecks[name]; ok {
+				log.Warnf("there is a built in check with the name: %s . the external wrapped script registered path: %s has the same base name", name, command)
+			}
 			runSet.cmdWraps[name] = CheckEntry{name, func() CheckHandler {
 				return &CheckWrap{name: name, commandString: strings.Join(command, " "), wrapped: true, config: cmdConf}
 			}}
@@ -107,35 +116,154 @@ func (e *ExternalScriptsHandler) registerWrapped(conf *Config, runSet *AgentRunS
 	return nil
 }
 
+func isExecutable(mode fs.FileMode) bool {
+	ownerExecutionBitmask := 0o0100
+	groupExecutableBitmask := 0o0010
+	othersExecutableBitmask := 0o001
+	executableByOwner := int(mode)&ownerExecutionBitmask != 0
+	executableByGroup := int(mode)&groupExecutableBitmask != 0
+	executableByOthers := int(mode)&othersExecutableBitmask != 0
+
+	return executableByOwner || executableByGroup || executableByOthers
+}
+
+//nolint:funlen,gocognit,gocyclo // cant take the walkDirFunc out, the signature is fixed and it writes to captured values outside
 func (e *ExternalScriptsHandler) registerScriptPath(defaultScriptConfig *ConfigSection, conf *Config) error {
-	scriptPath, ok := defaultScriptConfig.GetString("script path")
-	if !ok || scriptPath == "" {
+	configScriptPath, ok := defaultScriptConfig.GetString("script path")
+	if !ok || configScriptPath == "" {
 		return nil
 	}
 
-	_, err := os.Stat(scriptPath)
-	if os.IsNotExist(err) {
-		log.Warnf("script path %s: folder does not exist", scriptPath)
+	// the script path may have '**' at the end, which toggles recursive search within that directory
+	configScriptPath, recurseiveSearch := strings.CutSuffix(configScriptPath, "**")
+
+	var scriptPath string
+	var err error
+	if scriptPath, err = filepath.Abs(configScriptPath); err != nil {
+		return fmt.Errorf("could not get the absolute path from config script path %s : %w", configScriptPath, err)
+	}
+
+	stat, err := os.Stat(scriptPath)
+	if os.IsNotExist(err) || !stat.IsDir() {
+		return fmt.Errorf("script path %s: does not exist", scriptPath)
+	}
+
+	if !stat.IsDir() {
+		return fmt.Errorf("script path %s: is not a directory", scriptPath)
+	}
+
+	foundScriptPaths := make([]string, 0)
+
+	var walkDirFunc fs.WalkDirFunc
+
+	walkDirFunc = func(path string, dirEntry fs.DirEntry, err error) error {
+		// this type of function may have a non-nill error
+
+		// First, if the initial Stat on the root directory fails, WalkDir calls the function with path set to root, d set to nil, and err set to the error from fs.Stat.
+		if path == scriptPath && dirEntry == nil && err != nil {
+			return err
+		}
+
+		// Second, if a directory's ReadDir method (see ReadDirFile) fails, WalkDir calls the function with path set to the directory's path,
+		//  d set to an DirEntry describing the directory, and err set to the error from ReadDir.
+		if dirEntry != nil && err != nil {
+			return err
+		}
+
+		// cant use dirEntry, since symlink redirects recursive calls have dirEntry as nil
+		// need to take os.stat for executable permissions
+		stat, statErr := os.Stat(path)
+		if os.IsNotExist(statErr) {
+			return fmt.Errorf("path: %s, does not exist", path)
+		}
+		if statErr != nil {
+			return fmt.Errorf("error when getting os.Stat of the path: %s , %w", path, statErr)
+		}
+
+		// if file lies outside of scriptPath, skip it.
+		if !strings.HasPrefix(path, scriptPath) {
+			log.Tracef("path : %s is outside of the scriptPath : %s", path, scriptPath)
+
+			return nil
+		}
+
+		// if its an link, try to follow this link
+		lstat, errLstat := os.Lstat(path)
+		if errLstat == nil && (lstat.Mode().Type()&fs.ModeSymlink != 0) {
+			log.Tracef("Following the symlink with name: %s at path: %s", lstat.Name(), path)
+
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("reading the link failed, link path: %s", path)
+			}
+
+			if !filepath.IsAbs(linkTarget) {
+				linkTarget, err = filepath.Abs(filepath.Join(filepath.Dir(path), linkTarget))
+
+				if err != nil {
+					return fmt.Errorf("error when converting the link target to absolute path: %s , linkTarget: %s", path, linkTarget)
+				}
+			}
+
+			return walkDirFunc(linkTarget, nil, nil)
+		}
+
+		// optimization: if its a dir, return fs.SkipDir so that filepath.WalkDir can skip over the whole dir
+		if !recurseiveSearch && stat.IsDir() && path != scriptPath {
+			return fs.SkipDir
+		}
+
+		// Skip directories during the walk
+		if stat.IsDir() {
+			log.Tracef("skipping directory as a script to add: %s", path)
+
+			return nil
+		}
+
+		if filepath.Dir(path) != scriptPath && !recurseiveSearch {
+			log.Tracef("skipping file as a script to add: %s, recursiveSearch is not toggled", path)
+
+			return nil
+		}
+
+		// They have to be regular files.
+		if stat.Mode().Type()&fs.ModeIrregular != 0 {
+			log.Tracef("skipping file as a script to add: %s, its an irregular file", path)
+
+			return nil
+		}
+
+		// They have to be executable, available on some platforms
+		checkExecutableRuntimes := [5]string{"linux", "darwin", "netbsd", "openbsd"}
+		if slices.Contains(checkExecutableRuntimes[:], runtime.GOOS) {
+			if !isExecutable(stat.Mode().Perm()) {
+				log.Tracef("skipping file as a script to add: %s, go runtime is: %s, and the file is not executalbe with permissions: %d", path, runtime.GOOS, stat.Mode().Perm())
+
+				return nil
+			}
+		} else {
+			log.Tracef("file as a script to add: %s, go runtime is: %s, cannot determine if file is executable", path, runtime.GOOS)
+		}
+
+		log.Tracef("adding file as a script: %s", path)
+		foundScriptPaths = append(foundScriptPaths, path)
 
 		return nil
 	}
 
-	pattern := filepath.Join(scriptPath, "*.*")
-	log.Debugf("script path: loading all scripts matching: %s", pattern)
-	scripts, err := filepath.Glob(pattern)
-	if err != nil {
-		return fmt.Errorf("failed to list script path: %s", err.Error())
+	if err = filepath.WalkDir(scriptPath, walkDirFunc); err != nil {
+		return fmt.Errorf("error when walking directory: %w", err)
 	}
 
-	for _, command := range scripts {
-		name := filepath.Base(command)
+	for _, scriptPath := range foundScriptPaths {
+		name := filepath.Base(scriptPath)
 		cmdConf := conf.Section("/settings/external scripts/scripts/" + name)
 		if !cmdConf.HasKey("command") {
 			allow, _, _ := defaultScriptConfig.GetBool("allow arguments")
 			if allow {
-				cmdConf.Set("command", command+" %ARGS\"%")
+				cmdConf.Set("command", scriptPath+" %ARGS\"%")
 			} else {
-				cmdConf.Set("command", command)
+				cmdConf.Set("command", scriptPath)
 			}
 		}
 	}


### PR DESCRIPTION
External script discovery was using a glob with "*.*" as filter. This did not match files without extensions, and under UNIX systems executables can have no extension.

Instead of globbing, use filepath.WalkDir with a custom function. This function checks if a file is a regular file and executable before adding it to the list. Checking if a file is executable is only supported on unix platforms. If a file is a symlink, it will be followed up until it reaches a non-symlink file, and only added if its within the
 scriptPath.

Normal search only adds files that are found directly under scriptPath and not inside a subfolder. If the scriptPath ends with **, files in the subdirectories are added as well.

When adding new scripts, their names are searched if they match an existing check function.