### PR TITLE
fix check_files depth argument and windows paths

### DIFF
--- a/docs/checks/commands/check_files.md
+++ b/docs/checks/commands/check_files.md
@@ -61,7 +61,7 @@ Naemon Config
 | Argument  | Description                                                                                               |
 | --------- | --------------------------------------------------------------------------------------------------------- |
 | file      | Alias for path                                                                                            |
-| max-depth | Maximum recursion depth. Default: no limit. '0' disables recursion, '1' includes first sub folder level, etc... |
+| max-depth | Maximum recursion depth. Default: no limit. '0' disables recursion and only includes files/directories directly under path. '1' includes files/directories under the path directly under the path as well, '2' starts to include files/folders of directories of depth '1' and so forth.  |
 | path      | Path in which to search for files                                                                         |
 | paths     | A comma separated list of paths                                                                           |
 | pattern   | Pattern of files to search for                                                                            |

--- a/pkg/snclient/check_files.go
+++ b/pkg/snclient/check_files.go
@@ -2,12 +2,16 @@ package snclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/consol-monitoring/snclient/pkg/convert"
 	"github.com/consol-monitoring/snclient/pkg/humanize"
@@ -48,12 +52,13 @@ func (l *CheckFiles) Build() *CheckData {
 			State: CheckExitOK,
 		},
 		args: map[string]CheckArgument{
-			"path":      {value: &l.paths, description: "Path in which to search for files", isFilter: true},
-			"file":      {value: &l.paths, description: "Alias for path", isFilter: true},
-			"paths":     {value: &l.pathList, description: "A comma separated list of paths", isFilter: true},
-			"pattern":   {value: &l.pattern, description: "Pattern of files to search for", isFilter: true},
-			"max-depth": {value: &l.maxDepth, description: "Maximum recursion depth. Default: no limit. '0' disables recursion, '1' includes first sub folder level, etc..."},
-			"timezone":  {description: "Sets the timezone for time metrics (default is local time)"},
+			"path":    {value: &l.paths, description: "Path in which to search for files", isFilter: true},
+			"file":    {value: &l.paths, description: "Alias for path", isFilter: true},
+			"paths":   {value: &l.pathList, description: "A comma separated list of paths", isFilter: true},
+			"pattern": {value: &l.pattern, description: "Pattern of files to search for", isFilter: true},
+			"max-depth": {value: &l.maxDepth, description: "Maximum recursion depth. Default: no limit. '0' disables recursion and only includes files/directories directly under path." +
+				" '1' includes files/directories under the path directly under the path as well, '2' starts to include files/folders of directories of depth '1' and so forth. "},
+			"timezone": {description: "Sets the timezone for time metrics (default is local time)"},
 		},
 		detailSyntax: "%(name)",
 		okSyntax:     "%(status) - All %(count) files are ok: (%(total_size))",
@@ -105,11 +110,8 @@ func (l *CheckFiles) Check(_ context.Context, _ *Agent, check *CheckData, _ []Ar
 	}
 
 	for _, checkPath := range l.paths {
-		if l.maxDepth == 0 {
-			break
-		}
-
 		checkPath = l.normalizePath(checkPath)
+		log.Tracef("normalized checkPath: %s", checkPath)
 
 		err := filepath.WalkDir(checkPath, func(path string, dirEntry fs.DirEntry, err error) error {
 			return l.addFile(check, path, checkPath, dirEntry, err)
@@ -160,7 +162,11 @@ func (l *CheckFiles) Check(_ context.Context, _ *Agent, check *CheckData, _ []Ar
 }
 
 func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry fs.DirEntry, err error) error {
-	needVersion := check.HasThreshold("version") || check.HasMacro("version")
+	// if its a directory, checkPath is never added to the entry list
+	if dirEntry != nil && dirEntry.IsDir() && path == checkPath {
+		return nil
+	}
+
 	path = l.normalizePath(path)
 	filename := filepath.Base(path)
 	entry := map[string]string{
@@ -172,29 +178,52 @@ func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry 
 		"type":     "file",
 	}
 
-	pathDepth := l.getDepth(path, checkPath)
-	log.Tracef("entry: %s (depth: %d)", path, pathDepth)
-
-	if dirEntry != nil && dirEntry.IsDir() {
-		// start path is never returned
-		if path == checkPath {
-			return nil
-		}
-		entry["type"] = "dir"
-		if l.maxDepth != -1 && pathDepth > l.maxDepth {
-			log.Tracef("skipping dir, max-depth reached: %s", path)
-
-			return fs.SkipDir
-		}
-
-		if err != nil {
-			// silently skip failed sub folder
-			return fs.SkipDir
+	matchAndAdd := func() {
+		if check.MatchMapCondition(check.filter, entry, false) {
+			log.Tracef("path : %s, matched the map conditions appending to the check.listData", path)
+			check.listData = append(check.listData, entry)
+		} else {
+			log.Tracef("path : %s, did not match the map conditions", path)
 		}
 	}
 
-	if l.maxDepth != -1 && pathDepth > l.maxDepth {
-		log.Tracef("skipping file, max-depth reached: %s", path)
+	pathDepth := l.getDepth(path, checkPath)
+
+	if dirEntry != nil && dirEntry.IsDir() {
+		entry["type"] = "dir"
+
+		if err != nil {
+			// silently skip failed sub folder.
+			// If you continue on and the error is checked later, it will add error to the entry
+			// This will make tests fail.
+			return fs.SkipDir
+		}
+
+		// if recursion is disabled with maxDepth
+		if l.maxDepth != -1 && pathDepth >= 2 {
+			switch {
+			case pathDepth < l.maxDepth:
+				log.Tracef("dir: %s, pathDepth: %d, maxDepth: %d, possible to add dir, deferring to add", path, pathDepth, l.maxDepth)
+				defer matchAndAdd()
+
+				return nil
+			case pathDepth == l.maxDepth:
+				log.Tracef("dir: %s, pathDepth: %d, maxDepth: %d, possible to add dir, deferring to add and returning fs.Skipdir", path, pathDepth, l.maxDepth)
+				defer matchAndAdd()
+
+				return fs.SkipDir
+			default:
+				log.Tracef("dir: %s, pathDepth: %d, maxDepth: %d, can not add dir, returning fs.SkipDir", path, pathDepth, l.maxDepth)
+
+				return fs.SkipDir
+			}
+		}
+	}
+
+	// if recursion is disabled with maxDepth
+	if l.maxDepth != -1 && pathDepth >= 2 && pathDepth > l.maxDepth {
+		// for debugging
+		// log.Tracef("skipping file: %s, pathDepth: %d, max-depth:%d is lower", path, pathDepth, l.maxDepth)
 
 		return nil
 	}
@@ -207,11 +236,7 @@ func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry 
 		return nil
 	}
 
-	defer func() {
-		if check.MatchMapCondition(check.filter, entry, false) {
-			check.listData = append(check.listData, entry)
-		}
-	}()
+	defer matchAndAdd()
 
 	// check for errors here, maybe the file would have been filtered out anyway
 	if err != nil {
@@ -242,6 +267,7 @@ func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry 
 	entry["write"] = fmt.Sprintf("%d", fileInfoSys.Mtime.Unix())
 	entry["written"] = fmt.Sprintf("%d", fileInfoSys.Mtime.Unix())
 
+	needVersion := check.HasThreshold("version") || check.HasMacro("version")
 	if needVersion {
 		version, err := getFileVersion(path)
 		if err != nil {
@@ -381,7 +407,7 @@ func (l *CheckFiles) addFileMetrics(check *CheckData) {
 	}
 }
 
-// normalizePath returns a trimmed path without spaces and trailing slashes or leading ./
+// normalizePath returns a trimmed path without spaces, trailing / or \, leading ./ or .\
 func (l *CheckFiles) normalizePath(path string) string {
 	path = strings.TrimSpace(path)
 	path = strings.TrimPrefix(path, "./")
@@ -389,18 +415,51 @@ func (l *CheckFiles) normalizePath(path string) string {
 	path = strings.TrimSuffix(path, "/")
 	path = strings.TrimSuffix(path, string(os.PathSeparator))
 
+	// Special handling for Windows drive letters,
+	// Files directly under the drive do not have seperators, e.g: C:pagefile.sys
+	// This confuses the depth calculation
+	if runtime.GOOS == "windows" {
+		// "C:example" -> "C:\example".
+		// Do not change if its just the drive letter. D: -> D:
+		// Otherwise 'D:\' and 'D:\example' would have the same number of seperators, even though the file is under the D: "directory" and should have increased depth
+		if len(path) >= 3 && unicode.IsUpper(rune(path[0])) && path[1] == ':' && path[2] != '\\' {
+			winBasePath := path[:2] + string('\\') + path[2:]
+
+			return winBasePath
+		}
+	}
+
 	return path
 }
 
-// getDepth returns path depth starting at 0 with the top folder
+// getDepth returns path depth starting at 0 with for the basePath
 func (l *CheckFiles) getDepth(path, basePath string) int64 {
+	// both the path and BasePath are normalized once according to CheckFiles.normalizePath()
+	// Windows example:
+	// basePath: C:\foo
+	// path: C:\foo -> 0
+	// path: C:\foo\bar -> 1
+	// path: C:\foo\bar\baz -> 2
+
 	if path == basePath {
 		return 0
 	}
 
-	subPath := strings.TrimPrefix(path, basePath)
+	if !strings.HasPrefix(path, basePath) {
+		// for debugging
+		// log.Tracef("basePath: %s, is not a prefix of path: %s", basePath, path)
 
-	return int64(strings.Count(subPath, string(os.PathSeparator)))
+		return -1
+	}
+
+	subPath := strings.TrimPrefix(path, basePath)
+	seperatorCount := int64(strings.Count(subPath, string(os.PathSeparator)))
+	depth := seperatorCount
+
+	// for debugging
+	// log.Tracef("path: %s, basePath: %s, subPath: %s, seperatorCount: %d, depth: %d", path, basePath, subPath, seperatorCount, depth)
+
+	return depth
 }
 
 func (l *CheckFiles) setError(entry map[string]string, err error) {
@@ -410,6 +469,21 @@ func (l *CheckFiles) setError(entry map[string]string, err error) {
 	case os.IsPermission(err):
 		entry["_error"] = fmt.Sprintf("%s: file or directory not readable", entry["fullname"])
 	default:
-		entry["_error"] = fmt.Sprintf("%s: %s", entry["fullname"], err.Error())
+		// Handle *fs.PathError specifically
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) {
+			switch {
+			case errors.Is(pathErr, syscall.ENOENT):
+				entry["_error"] = fmt.Sprintf("%s: no such file or directory", entry["fullname"])
+			case errors.Is(pathErr, syscall.EACCES):
+				entry["_error"] = fmt.Sprintf("%s: file or directory not readable", entry["fullname"])
+			case errors.Is(pathErr, syscall.EPERM):
+				entry["_error"] = fmt.Sprintf("%s: file or directory not readable", entry["fullname"])
+			default:
+				entry["_error"] = fmt.Sprintf("%s: %s", entry["fullname"], pathErr.Err.Error())
+			}
+		} else {
+			entry["_error"] = fmt.Sprintf("%s: %s", entry["fullname"], err.Error())
+		}
 	}
 }

--- a/pkg/snclient/check_files_linux_test.go
+++ b/pkg/snclient/check_files_linux_test.go
@@ -1,0 +1,113 @@
+package snclient
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func checkFilesTestConfig(t *testing.T, scriptsDir string) string {
+	t.Helper()
+
+	config := fmt.Sprintf(`
+[/modules]
+CheckExternalScripts = enabled
+
+[/paths]
+scripts = %s
+shared-path = %%(scripts)
+
+[/settings/external scripts]
+timeout = 1111111
+allow arguments = true
+
+[/settings/external scripts/scripts]
+check_files_recurisve_generate_files = ./check_files_recursive_generate_files.sh "$ARG1$"
+`, scriptsDir)
+
+	return config
+}
+
+func TestCheckFilesRecursiveArguments(t *testing.T) {
+	testDir, _ := os.Getwd()
+	scriptsDir := filepath.Join(testDir, "t", "scripts")
+
+	config := checkFilesTestConfig(t, scriptsDir)
+	snc := StartTestAgent(t, config)
+
+	// capture this since t.TempDir() is dyanic
+	geneartionDirectory := t.TempDir()
+
+	res := snc.RunCheck("check_files_recurisve_generate_files", []string{geneartionDirectory})
+	assert.Equalf(t, CheckExitOK, res.State, "state matches")
+
+	assert.Containsf(t, string(res.BuildPluginOutput()), "ok - Generated 11 files for testing", "output matches")
+	assert.Containsf(t, string(res.BuildPluginOutput()), "ok - Generated 6 directories for testing", "output matches")
+
+	// The script should build a file three that looks like this
+	// /tmp/TestCheckFilesRecursiveArguments86871339/003
+	// ├── directory1
+	// │   ├── directory1-directory2
+	// │   │   ├── directory1-directory2-directory3
+	// │   │   │   └── directory1-directory2-directory3-file8
+	// │   │   ├── directory1-directory2-file5
+	// │   │   ├── directory1-directory2-file6
+	// │   │   └── directory1-directory2-file7
+	// │   ├── directory1-file3.txt
+	// │   └── directory1-file4
+	// ├── directory4
+	// │   ├── directory4-directory5
+	// │   │   └── directory4-directory5-file11
+	// │   ├── directory4-directory6
+	// │   ├── directory4-file10.html
+	// │   └── directory4-file9.exe
+	// ├── file1.txt
+	// └── file2
+
+	// No arguments: Recursion enabled. Should find everything under the folder.
+	// 11 files and 6 folders => Reports 17 files
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 17 files are ok", "output matches")
+
+	// Max-depth=0
+	// Depth is calculated by the amount of seperators from the base path
+	// So only the path itself is going to have depth 0. Anything under it requires an appended /
+	// But the check will always include files directly under it
+	// file1.txt , file2 , directory1 , directory2
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "max-depth=0"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 4 files are ok", "output matches")
+
+	// Max-depth=1
+	// These items fit the depth condition, as they require one more separator to type after the base path
+	// file1.txt , file2 , directory1 , directory2
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "max-depth=1"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 4 files are ok", "output matches")
+
+	// Max-depth=2
+	// file1.txt , file2 , directory1 , directory1-file3.txt, directory1-file4 , directory1-directory2, directory4,
+	// directory4-file9.exe , directory4-file10.html , directory4-directory5 , directory4-directory6
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "max-depth=2"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 11 files are ok", "output matches")
+
+	// Max-depth=3
+	// Adds 5 more: directory1-directory2-directory3, directory1-directory2-file5 , directory1-directory2-file6, directory1-directory2-file7, directory4-directory5-file11
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "max-depth=3"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 16 files are ok", "output matches")
+
+	// Max-depth=4
+	// Adds the last file: directory1-directory2-directory3-file8
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "max-depth=4"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 17 files are ok", "output matches")
+
+	// File and directory type checks
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "filter='type=file'"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 11 files are ok", "output matches")
+
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "filter='type=dir'"})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 6 files are ok", "output matches")
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/check_files_test.go
+++ b/pkg/snclient/check_files_test.go
@@ -28,8 +28,8 @@ func TestCheckFiles(t *testing.T) {
 	assert.Contains(t, string(res.BuildPluginOutput()), "'count'=")
 
 	res = snc.RunCheck("check_files", []string{"path=.", "max-depth=0"})
-	assert.Equalf(t, CheckExitUnknown, res.State, "state Unknown")
-	assert.Contains(t, string(res.BuildPluginOutput()), "No files found")
+	assert.Equalf(t, CheckExitOK, res.State, "state OK")
+	assert.NotContains(t, string(res.BuildPluginOutput()), "No files found")
 
 	res = snc.RunCheck("check_files", []string{"paths= ., t", "crit=count>10000", "max-depth=1"})
 	assert.Equalf(t, CheckExitOK, res.State, "state OK")

--- a/pkg/snclient/t/scripts/check_files_recursive_generate_files.sh
+++ b/pkg/snclient/t/scripts/check_files_recursive_generate_files.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script is intended to generate files to be tested for check_files
+# These files need to be generated dynamically, so they cant be simply saved in the repository.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TESTING_DIR="$1"
+
+mkdir -p ${TESTING_DIR}
+
+# Generate it with local timezone
+TODAY=$(date -d 'today 00:00:00' +%F)
+
+(
+    cd ${TESTING_DIR}
+
+    mkdir -p ${TESTING_DIR}
+
+    touch ${TESTING_DIR}/file1.txt
+    touch ${TESTING_DIR}/file2
+    mkdir -p ${TESTING_DIR}/directory1
+    touch ${TESTING_DIR}/directory1/directory1-file3.txt
+    touch ${TESTING_DIR}/directory1/directory1-file4
+    mkdir -p ${TESTING_DIR}/directory1/directory1-directory2
+    touch ${TESTING_DIR}/directory1/directory1-directory2/directory1-directory2-file5
+    touch ${TESTING_DIR}/directory1/directory1-directory2/directory1-directory2-file6
+    touch ${TESTING_DIR}/directory1/directory1-directory2/directory1-directory2-file7
+    mkdir -p ${TESTING_DIR}/directory1/directory1-directory2/directory1-directory2-directory3
+    touch ${TESTING_DIR}/directory1/directory1-directory2/directory1-directory2-directory3/directory1-directory2-directory3-file8
+    mkdir -p ${TESTING_DIR}/directory4
+    touch ${TESTING_DIR}/directory4/directory4-file9.exe
+    touch ${TESTING_DIR}/directory4/directory4-file10.html
+    mkdir -p ${TESTING_DIR}/directory4/directory4-directory5
+    mkdir -p ${TESTING_DIR}/directory4/directory4-directory6
+    touch ${TESTING_DIR}/directory4/directory4-directory5/directory4-directory5-file11
+
+    FILE_COUNT=$(find ${TESTING_DIR} -type f -printf "." | wc -c)
+    echo "ok - Generated ${FILE_COUNT} files for testing"
+
+    # This also counts the TESTING_DIR
+    DIRECTORY_COUNT=$(find ${TESTING_DIR} -type d -printf "." | wc -c)
+    #echo "DIRECTORY_COUNT=${DIRECTORY_COUNT}"
+    echo "ok - Generated $(( DIRECTORY_COUNT - 1 )) directories for testing"
+
+    echo "printing the tree of the files"
+    tree ${TESTING_DIR}
+)
+
+exit 0


### PR DESCRIPTION
the maxDepth argument was confusing, as it did not include anything when it was set to 0, clarify its usage better in the documentation. make max-depth argument '0' and '1' include files/directories directly under the path. now a search with max-depth=0 is valid and does not return empty output

optimize the folder skipping, where if max-depth is specified and the directories depth is exactly the max depth, it will be possibly added and fs.SkipDir is immediately returned. previously it would only return if depth>max depth, which increased search time a lot when searched from a drive

move some of the early guards/returns around so that they can be called earlier, move the needVersion variable as well. add comments about return calls and their intended effect