### PR TITLE
shove -v,-vv,-vvv arguments to the front only if its using an internal check

### DIFF
--- a/pkg/snclient/snclient.go
+++ b/pkg/snclient/snclient.go
@@ -1334,13 +1334,14 @@ func (snc *Agent) setDefaultPaths(config *Config, configFiles []string) *ConfigS
 func (snc *Agent) MakeCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 	// wrap the platform specific command builder
 	cmd, err := snc.makeCmd(ctx, command)
+	workingDirectory, _ := os.Getwd()
 	switch {
 	case err != nil:
 		return nil, err
 	case cmd.Args != nil:
-		log.Tracef("command object:\n path: %s\n args: %v\n SysProcAttr: %v\n", cmd.Path, cmd.Args, cmd.SysProcAttr)
+		log.Tracef("command object:\n path: %s\n args: %v\n dir: %s\n workingDirectory: %s\n SysProcAttr: %v\n", cmd.Path, cmd.Args, cmd.Dir, workingDirectory, cmd.SysProcAttr)
 	default:
-		log.Tracef("command object:\n path: %s\n args: (none)\n SysProcAttr: %v\n", cmd.Path, cmd.SysProcAttr)
+		log.Tracef("command object:\n path: %s\n args: (none)\n dir: %s\n workingDirectory: %s\n SysProcAttr: %v\n", cmd.Path, cmd.Dir, workingDirectory, cmd.SysProcAttr)
 	}
 
 	return cmd, err


### PR DESCRIPTION
this fixes the problem where external scripts that take these arguments would have their argument taken away, as snclient would shove it to the front of the commandline and use it as its own flag.

additionally, print some more details when running an external command