### PR TITLE
fix the check_drive_io output, which had missing values in its entryData

### DIFF
--- a/pkg/snclient/check_drive_io_windows.go
+++ b/pkg/snclient/check_drive_io_windows.go
@@ -6,7 +6,9 @@ import (
 	"maps"
 	"time"
 
+	"github.com/consol-monitoring/snclient/pkg/convert"
 	"github.com/consol-monitoring/snclient/pkg/counter"
+	"github.com/consol-monitoring/snclient/pkg/humanize"
 	"github.com/shirou/gopsutil/v4/disk"
 )
 
@@ -30,6 +32,10 @@ func (l *CheckDriveIO) buildEntry(snc *Agent, diskIOCounters any, deviceLogicalN
 		return false
 	}
 
+	// Windows IoCountersStat does not return a Label
+	// Might have to find it somewhere else
+	entry["label"] = ""
+
 	// counters use this format when saving metrics
 	// found in CheckSystemHandler.addLinuxDiskStats
 	counterCategory := "disk_" + counters.Name
@@ -38,12 +44,18 @@ func (l *CheckDriveIO) buildEntry(snc *Agent, diskIOCounters any, deviceLogicalN
 	l.addRateToEntry(snc, entry, "read_count_rate", counterCategory, "read_count")
 	entry["read_bytes"] = fmt.Sprintf("%d", counters.ReadBytes)
 	l.addRateToEntry(snc, entry, "read_bytes_rate", counterCategory, "read_bytes")
+	readBytesRateFloat64 := convert.Float64(entry["read_bytes_rate"])
+	humanizedReadBytesRate := humanize.IBytesF(uint64(readBytesRateFloat64), 1)
+	entry["read_bytes_rate_humanized"] = humanizedReadBytesRate + "/s"
 	entry["read_time"] = fmt.Sprintf("%f", counters.ReadTime)
 
 	entry["write_count"] = fmt.Sprintf("%d", counters.WriteCount)
 	l.addRateToEntry(snc, entry, "write_count_rate", counterCategory, "write_count")
 	entry["write_bytes"] = fmt.Sprintf("%d", counters.WriteBytes)
 	l.addRateToEntry(snc, entry, "write_bytes_rate", counterCategory, "write_bytes")
+	writeBytesRateFloat64 := convert.Float64(entry["write_bytes_rate"])
+	humanizedWriteBytesRate := humanize.IBytesF(uint64(writeBytesRateFloat64), 1)
+	entry["write_bytes_rate_humanized"] = humanizedWriteBytesRate + "/s"
 	entry["write_time"] = fmt.Sprintf("%f", counters.WriteTime)
 
 	entry["idle_time"] = fmt.Sprintf("%d", counters.IdleTime)

--- a/pkg/snclient/task_check_system_windows.go
+++ b/pkg/snclient/task_check_system_windows.go
@@ -373,12 +373,12 @@ func (c *CheckSystemHandler) addDiskStats(create bool) {
 		c.snc.Counter.Set(category, "write_count", float64(diskIOCounters[diskName].WriteCount))
 		c.snc.Counter.Set(category, "read_bytes", float64(diskIOCounters[diskName].ReadBytes))
 		c.snc.Counter.Set(category, "read_count", float64(diskIOCounters[diskName].ReadCount))
-		c.snc.Counter.Set(category, "idle_time", float64(diskIOCounters[diskName].IdleTime))
-		// important to put the query_time in uint64 form
+		// important to put the query_time and idle_time uint64 form
 		// it is some kind of nanosecond counter starting from long ago
 		// even current values on 2026, the value has log2 around 56
 		// float64 has 53 bits of significant precision, it loses precision
 		// makes calculating utilization impossible
+		c.snc.Counter.Set(category, "idle_time", diskIOCounters[diskName].IdleTime)
 		c.snc.Counter.Set(category, "query_time", diskIOCounters[diskName].QueryTime)
 	}
 }


### PR DESCRIPTION
add read/write_bytes_rate humanized, used when building the output. it was missing on windows, but present in others

add an empty label, as windows diskIOCounters does not return the label. Have to get it from somehwere else



now the output looks proper in default invocation:

OK - C >2.2 MiB/s <1.8 MiB/s 3.6%, D >0 B/s <170.5 MiB/s 78.8%, E >0 B/s <0 B/s 0.0%, F >0 B/s <0 B/s -0.0%, G >0 B/s <0 B/s -0.0%, H >0 B/s <11.0 B/s 0.0%, I >0 B/s <0 B/s -0.0% |'C_read_count'=5419844c;;;0; 'C_read_bytes'=79799404032c;;;0; 'C_read_time'=4415455.7729ms;;;0; 'C_write_count'=2347106c;;;0; 'C_write_bytes'=53242277888c;;;0; 'C_write_time'=1626288.63ms;;;0; 'C_utilization'=3.6%;95;;0; 'C_queue_depth'=0;;;0; 'D_read_count'=396150c;;;0; 'D_read_bytes'=193035745792c;;;0; 'D_read_time'=231358690.6178ms;;;0; 'D_write_count'=279715c;;;0; 'D_write_bytes'=145494068224c;;;0; 'D_write_time'=2911921.3152ms;;;0; 'D_utilization'=78.8%;95;;0; 'D_queue_depth'=1;;;0; 'E_read_count'=1529c;;;0; 'E_read_bytes'=6730240c;;;0; 'E_read_time'=219.544ms;;;0; 'E_write_count'=434c;;;0; 'E_write_bytes'=2816512c;;;0; 'E_write_time'=131.795ms;;;0; 'E_utilization'=0%;95;;0; 'E_queue_depth'=0;;;0; 'F_read_count'=85954c;;;0; 'F_read_bytes'=49837942272c;;;0; 'F_read_time'=191631.3353ms;;;0; 'F_write_count'=102906c;;;0; 'F_write_bytes'=102907612160c;;;0; 'F_write_time'=1662286.1347ms;;;0; 'F_utilization'=-0%;95;;0; 'F_queue_depth'=0;;;0; 'G_read_count'=1927c;;;0; 'G_read_bytes'=136574976c;;;0; 'G_read_time'=706.3519ms;;;0; 'G_write_count'=75c;;;0; 'G_write_bytes'=323584c;;;0; 'G_write_time'=34.0137ms;;;0; 'G_utilization'=-0%;95;;0; 'G_queue_depth'=0;;;0; 'H_read_count'=7292c;;;0; 'H_read_bytes'=80874496c;;;0; 'H_read_time'=69007.7321ms;;;0; 'H_write_count'=3438c;;;0; 'H_write_bytes'=20377600c;;;0; 'H_write_time'=20552.0979ms;;;0; 'H_utilization'=0%;95;;0; 'H_queue_depth'=0;;;0; 'I_read_count'=907c;;;0; 'I_read_bytes'=2675200c;;;0; 'I_read_time'=1197.4559ms;;;0; 'I_write_count'=197c;;;0; 'I_write_bytes'=1462272c;;;0; 'I_write_time'=72.6853ms;;;0; 'I_utilization'=-0%;95;;0; 'I_queue_depth'=0;;;0;