### PR TITLE
support per-drive crit/warning thresholds by adding metrics when needed

### DIFF
--- a/docs/checks/commands/check_drivesize.md
+++ b/docs/checks/commands/check_drivesize.md
@@ -33,6 +33,10 @@ Check folder, no matter if its a mountpoint itself or not:
     check_drivesize folder=/tmp show-all
     OK - /tmp 280.155 GiB/455.948 GiB (64.7%) |...
 
+This check supports specifying different usage thresholds for each drive. Use '[drive] used_pct' or '[drive] used %' in the condition:
+	check_drivesize "drive=/" "drive=/tmp" "warn='/ used_pct' gt 70" "crit='/tmp used %' > 1"
+	CRITICAL - / 428.040 GiB/935.929 GiB (45.7%), /tmp 471.496 MiB/31.127 GiB (1.5%) |'/ used'=459604856832B;;;0;1004946423808 '/ used %'=45.7%;70;;0;100 '/tmp used'=494399488B;;;0;33422544896 '/tmp used %'=1.5%;;1;0;100
+
 ### Example using NRPE and Naemon
 
 Naemon Config

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -304,18 +304,24 @@ func (l *CheckDrivesize) addMetrics(drive string, check *CheckData, usage *disk.
 		total = usage.Used + usage.Free // use this total instead of usage.Total to account in the root reserved space
 	}
 
-	// need to detect conditions where the operand is named '<drive> used %', this is the default way snclient names percent usage metrics.
-	// if there is a condition using that as an operand, add usage metrics for that drive as well. these metrics will be added for that drive only.
-	// this helps to check usage metrics specific to drives.
-	percentageUsageMetric := fmt.Sprintf("%s used %%", drive)
-
 	if check.HasThreshold("free") || check.HasThreshold("free_pct") || check.HasThreshold("free_bytes") {
 		check.warnThreshold = check.TransformMultipleKeywords([]string{"free_pct", "free_bytes"}, "free", check.warnThreshold)
 		check.critThreshold = check.TransformMultipleKeywords([]string{"free_pct", "free_bytes"}, "free", check.critThreshold)
 		check.AddBytePercentMetrics("free", drive+" free", magic*float64(usage.Free), magic*float64(total))
 	}
 
-	if check.HasThreshold(percentageUsageMetric) || check.HasThreshold("used") || check.HasThreshold("used_pct") || check.HasThreshold("used_bytes") {
+	// convert '<drive> used_pct' keywords in conditions to '<drive> used %' as that matches the metric name
+	convertDriveUsagePctMetric1 := fmt.Sprintf("%s used_pct", drive)
+	// metrics are normally added if the operand is simply 'used' , 'used_pct' , 'used_bytes' etc. and do not have a drive prefix
+	// detect conditions where the operand is named '<drive> used %', this is the default way snclient names percent usage metrics.
+	// if there is a condition using that as an operand, add usage metrics for that drive as well. during the metrics condition checking, they will take effect.
+	// this helps to check usage metrics specific to drives.
+	driveUsagePctMetric := fmt.Sprintf("%s used %%", drive)
+
+	check.warnThreshold = check.TransformMultipleKeywords([]string{convertDriveUsagePctMetric1}, driveUsagePctMetric, check.warnThreshold)
+	check.critThreshold = check.TransformMultipleKeywords([]string{convertDriveUsagePctMetric1}, driveUsagePctMetric, check.critThreshold)
+
+	if check.HasThreshold(driveUsagePctMetric) || check.HasThreshold("used") || check.HasThreshold("used_pct") || check.HasThreshold("used_bytes") {
 		check.warnThreshold = check.TransformMultipleKeywords([]string{"used_pct", "used_bytes"}, "used", check.warnThreshold)
 		check.critThreshold = check.TransformMultipleKeywords([]string{"used_pct", "used_bytes"}, "used", check.critThreshold)
 		check.AddBytePercentMetrics("used", drive+" used", magic*float64(usage.Used), magic*float64(total))

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -304,12 +304,18 @@ func (l *CheckDrivesize) addMetrics(drive string, check *CheckData, usage *disk.
 		total = usage.Used + usage.Free // use this total instead of usage.Total to account in the root reserved space
 	}
 
+	// need to detect conditions where the operand is named '<drive> used %', this is the default way snclient names percent usage metrics.
+	// if there is a condition using that as an operand, add usage metrics for that drive as well. these metrics will be added for that drive only.
+	// this helps to check usage metrics specific to drives.
+	percentageUsageMetric := fmt.Sprintf("%s used %%", drive)
+
 	if check.HasThreshold("free") || check.HasThreshold("free_pct") || check.HasThreshold("free_bytes") {
 		check.warnThreshold = check.TransformMultipleKeywords([]string{"free_pct", "free_bytes"}, "free", check.warnThreshold)
 		check.critThreshold = check.TransformMultipleKeywords([]string{"free_pct", "free_bytes"}, "free", check.critThreshold)
 		check.AddBytePercentMetrics("free", drive+" free", magic*float64(usage.Free), magic*float64(total))
 	}
-	if check.HasThreshold("used") || check.HasThreshold("used_pct") || check.HasThreshold("used_bytes") {
+
+	if check.HasThreshold(percentageUsageMetric) || check.HasThreshold("used") || check.HasThreshold("used_pct") || check.HasThreshold("used_bytes") {
 		check.warnThreshold = check.TransformMultipleKeywords([]string{"used_pct", "used_bytes"}, "used", check.warnThreshold)
 		check.critThreshold = check.TransformMultipleKeywords([]string{"used_pct", "used_bytes"}, "used", check.critThreshold)
 		check.AddBytePercentMetrics("used", drive+" used", magic*float64(usage.Used), magic*float64(total))

--- a/pkg/snclient/check_drivesize_other.go
+++ b/pkg/snclient/check_drivesize_other.go
@@ -16,6 +16,7 @@ func (l *CheckDrivesize) getDefaultFilter() string {
 	return "fstype not in (" + utils.List2String(defaultExcludedFsTypes()) + ")"
 }
 
+//nolint:lll // Explanations are long
 func (l *CheckDrivesize) getExample() string {
 	return `
     check_drivesize drive=/ show-all
@@ -30,6 +31,10 @@ Check folder, no matter if its a mountpoint itself or not:
 
     check_drivesize folder=/tmp show-all
     OK - /tmp 280.155 GiB/455.948 GiB (64.7%) |...
+
+This check supports specifying different usage thresholds for each drive. Use '[drive] used_pct' or '[drive] used %' in the condition:
+	check_drivesize "drive=/" "drive=/tmp" "warn='/ used_pct' gt 70" "crit='/tmp used %' > 1"
+	CRITICAL - / 428.040 GiB/935.929 GiB (45.7%), /tmp 471.496 MiB/31.127 GiB (1.5%) |'/ used'=459604856832B;;;0;1004946423808 '/ used %'=45.7%;70;;0;100 '/tmp used'=494399488B;;;0;33422544896 '/tmp used %'=1.5%;;1;0;100
 	`
 }
 

--- a/pkg/snclient/condition.go
+++ b/pkg/snclient/condition.go
@@ -229,7 +229,12 @@ func NewCondition(input string, attr *[]CheckAttribute) (*Condition, error) {
 
 func (c *Condition) String() string {
 	if c.original != "" {
-		return c.original
+		// keyword might have been changed by a transform function, print it out separately if that is the case
+		if strings.Contains(c.original, c.keyword) {
+			return c.original
+		}
+
+		return fmt.Sprintf("(original: %s | keyword: %s)", c.original, c.keyword)
 	}
 
 	if len(c.group) > 0 {


### PR DESCRIPTION
By default, snclient does not add unnecessary metrics if they do not occur in a condition. This is done by checking the operand of conditions using check.HasThreshold() function

Adding used_pct adds metrics per drive: '[drive] used' and '[drive] used %' , but if it is not present these metrics will be missing.
```bash
./snclient -vvv --logfile stdout run check_drivesize "drive=/" "warn=used_pct gt 50" show-all
OK - / 428.610 GiB/935.929 GiB (45.8%) |'/ used'=460216111104B;502473211904;904451781427;0;1004946423808 '/ used %'=45.8%;50;90;0;100
```

But adding a bare warn='used_pct gt 90' would affect all drives. To check multiple drives while specifying different thresholds for each drive, we need to add the percentage usage metrics. Metrics are also checked when finalizing the check, and can influence the final state.

```bash
./snclient -vvv --logfile stdout run check_drivesize "drive=/" "drive=/tmp" "warn='/ used %' gt 30" "crit='/tmp used %' gt 66" show-all
WARNING - / 428.867 GiB/935.929 GiB (45.8%), /tmp 961.945 MiB/31.127 GiB (3.0%) |'/ used'=460492066816B;;;0;1004946423808 '/ used %'=45.8%;30;;0;100 '/tmp used'=1008672768B;;;0;33422544896 '/tmp used %'=3%;;66;0;100
```

Detect conditions where the operand is named '[drive] used %', if there is a condition using that as operator, add usage metrics for that drive as well. This only works on that drive, and since the operand '[drive] used %' is different for each drive, it wont effect other drives perfdata.