### PR TITLE
Check files improve path normalization

### DIFF
--- a/pkg/snclient/check_files.go
+++ b/pkg/snclient/check_files.go
@@ -598,7 +598,7 @@ func (l *CheckFiles) normalizePath(path string) string {
 		path = fromSlash
 	}
 
-	// Remove groups of seperators next to each other , and replace them with a single seperator
+	// Remove groups of seperators next to each other , and replace them with a single separator
 	sep := string(os.PathSeparator)
 	for strings.Contains(path, sep+sep) {
 		path = strings.ReplaceAll(path, sep+sep, sep)

--- a/pkg/snclient/check_files.go
+++ b/pkg/snclient/check_files.go
@@ -593,6 +593,18 @@ func (l *CheckFiles) normalizePath(path string) string {
 	// Files directly under the drive do not have separators, e.g: C:pagefile.sys
 	// This confuses the depth calculation
 	if runtime.GOOS == "windows" {
+		// Convert forward slashes to backward slashes
+		fromSlash := filepath.FromSlash(path)
+		path = fromSlash
+	}
+
+	// Remove groups of seperators next to each other , and replace them with a single seperator
+	sep := string(os.PathSeparator)
+	for strings.Contains(path, sep+sep) {
+		path = strings.ReplaceAll(path, sep+sep, sep)
+	}
+
+	if runtime.GOOS == "windows" {
 		// C: -> C:\
 		if len(path) == 2 && unicode.IsUpper(rune(path[0])) && path[1] == ':' {
 			// Ensure drive letters always have a backslash: "C:" -> "C:\"

--- a/pkg/snclient/check_files_windows_test.go
+++ b/pkg/snclient/check_files_windows_test.go
@@ -88,3 +88,31 @@ func TestCheckDriveLetterPaths(t *testing.T) {
 
 	StopTestAgent(t, snc)
 }
+
+func TestCheckPathSpecifications(t *testing.T) {
+	snc := StartTestAgent(t, "")
+	var res *CheckResult
+
+	// ===============  C:\Windows\Fonts\arial.ttf
+	// Intended seperator is backward slashes like this
+	res = snc.RunCheck("check_files", []string{"path=C:\\Windows\\fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
+
+	// Forward slashes should be converted to backward slashes
+	res = snc.RunCheck("check_files", []string{"path=C:/Windows/fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
+
+	// Multiple backward slashes that do not actually go into subfolders and add depth should be ignored
+	res = snc.RunCheck("check_files", []string{"path=C:\\\\\\Windows\\\\fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
+
+	// Multiple backward slashes that do not actually go into subfolders and add depth should be ignored
+	res = snc.RunCheck("check_files", []string{"path=C:\\\\Windows\\\\fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
+
+	// Multiple forward slashes that do not actually go into subfolders and add depth should be ignored
+	res = snc.RunCheck("check_files", []string{"path=C://Windows////fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/check_files_windows_test.go
+++ b/pkg/snclient/check_files_windows_test.go
@@ -94,7 +94,7 @@ func TestCheckPathSpecifications(t *testing.T) {
 	var res *CheckResult
 
 	// ===============  C:\Windows\Fonts\arial.ttf
-	// Intended seperator is backward slashes like this
+	// Intended separator is backward slashes like this
 	res = snc.RunCheck("check_files", []string{"path=C:\\Windows\\fonts", "max-depth=1", "filter= type == 'file' and name == 'arial.ttf' "})
 	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - All 1 files are ok", "output matches")
 


### PR DESCRIPTION
1) path normalization function cleans up the paths better, by switching to filesystem separator first.

normalized path is used for depth calculation. the depth is the count difference of filesystem separators

it is also used to check if an filesystem item is inside another filesystem item. 

for windows, the paths could be specified using forward slashes like this: "C:/Windows". This meant that this block in normalizePath would run and append a backward slash making the path "C:\\/Windows" .

```golang
	if runtime.GOOS == "windows" {
		// C: -> C:\
		if len(path) == 2 && unicode.IsUpper(rune(path[0])) && path[1] == ':' {
			// Ensure drive letters always have a backslash: "C:" -> "C:\"
			return path + string(os.PathSeparator)
		}
		// "C:example" -> "C:\example".
		if len(path) >= 3 && unicode.IsUpper(rune(path[0])) && path[1] == ':' && path[2] != '\\' {
			winBasePath := path[:2] + string('\\') + path[2:]

			return winBasePath
		}
	}
```

Discovered files would look like "C:/Windows/test.txt" and would not be considered as under "C:\\/Windows", breaking the check.

convert forward slashes to backward slashes using filepath.FromSlash before that block.


2) For all platforms: 
Replace groups of separators into a single separator. This prevents a////b////c from having higher depth than a/b/c . 

Fixing this issue as well, it did not come from a bug report but found while looking through the code.