### PR TITLE
check files: skip files with whitespace names

### DIFF
--- a/docs/checks/commands/check_files.md
+++ b/docs/checks/commands/check_files.md
@@ -23,12 +23,12 @@ Checks files and directories.
 Alert if there are logs older than 1 hour in /tmp:
 
     check_files path="/tmp" pattern="*.log" "filter=age > 1h" crit="count > 0" empty-state=0 empty-syntax="no old files found" top-syntax="found %(count) too old logs"
-    OK - All 138 files are ok: (29.22 MiB) |'count'=138;500;600;0 'size'=30642669B;;;0
+    OK - All 138 files are ok: (29.22 MiB) |'count'=138;500;600;0 'total_size'=30642669B;;;0
 
 Check for folder size:
 
     check_files 'path=/tmp' 'warn=total_size > 200MiB' 'crit=total_size > 300MiB'
-    OK - All 145 files are ok: (34.72 MiB) |'count'=145;;;0 'size'=36406741B;209715200;314572800;0
+    OK - All 145 files are ok: (34.72 MiB) |'count'=145;;;0 'total_size'=36406741B;209715200;314572800;0
 
 ### Example using NRPE and Naemon
 

--- a/pkg/snclient/check_files.go
+++ b/pkg/snclient/check_files.go
@@ -33,7 +33,7 @@ type CheckFiles struct {
 	paths                      []string
 	pathList                   CommaStringList
 	pattern                    string // constructor NewCheckFiles sets this as '*'
-	maxDepth                   int64  // constructor NewCheckFiles sets this as -1
+	maxDepth                   int64  // constructor NewCheckFiles sets this as -1. -1 disables recursion while checking paths.
 	calculateSubdirectorySizes bool   // constructor NewCheckFiles sets this as false
 }
 
@@ -98,12 +98,12 @@ func (l *CheckFiles) Build() *CheckData {
 Alert if there are logs older than 1 hour in /tmp:
 
     check_files path="/tmp" pattern="*.log" "filter=age > 1h" crit="count > 0" empty-state=0 empty-syntax="no old files found" top-syntax="found %(count) too old logs"
-    OK - All 138 files are ok: (29.22 MiB) |'count'=138;500;600;0 'size'=30642669B;;;0
+    OK - All 138 files are ok: (29.22 MiB) |'count'=138;500;600;0 'total_size'=30642669B;;;0
 
 Check for folder size:
 
     check_files 'path=/tmp' 'warn=total_size > 200MiB' 'crit=total_size > 300MiB'
-    OK - All 145 files are ok: (34.72 MiB) |'count'=145;;;0 'size'=36406741B;209715200;314572800;0
+    OK - All 145 files are ok: (34.72 MiB) |'count'=145;;;0 'total_size'=36406741B;209715200;314572800;0
 	`,
 		exampleArgs: `'path=/tmp' 'filter=age > 3d' 'warn=count > 500' 'crit=count > 600'`,
 	}
@@ -153,6 +153,7 @@ func (l *CheckFiles) Check(_ context.Context, _ *Agent, check *CheckData, _ []Ar
 	return check.Finalize()
 }
 
+//nolint:gocyclo // this function is delegating to other functions as much as it can
 func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry fs.DirEntry, err error) error {
 	// if the search path is a directory e.g '/usr/bin' , the program assumes you are looking for files/subdirectories under it
 	// therefore it does not add the search path directory to the entry list
@@ -161,8 +162,16 @@ func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry 
 		return nil
 	}
 
+	originalFilename := filepath.Base(path)
+	if strings.TrimSpace(originalFilename) == "" {
+		log.Tracef("skipping entry with whitespace-only name: '%s' ", path)
+
+		return nil
+	}
+
 	path = l.normalizePath(path)
 	filename := filepath.Base(path)
+
 	entry := map[string]string{
 		"file":       filename,
 		"filename":   filename,
@@ -227,6 +236,7 @@ func (l *CheckFiles) addFile(check *CheckData, path, checkPath string, dirEntry 
 	// check filter and pattern before doing more expensive things
 	// pattern matching is only done on files, directories are always added
 	// directories that do not have any matched files under them are later removed
+	// IMPORTANT: filepath.Match uses shell type matching, NOT REGEX. This is the intended way the pattern works.
 	if match, _ := filepath.Match(l.pattern, entry["filename"]); entry["type"] == "file" && !match {
 		log.Tracef("filename: %s did not match the pattern: %s , skipping", entry["filename"], l.pattern)
 
@@ -412,18 +422,16 @@ func (l *CheckFiles) addGeneralMetrics(check *CheckData) {
 
 	// entries in listData have a 'size' attribute. This is filled for files directly, with folders they have to be calculated after the walk has ended.
 	// total_size argument is the recommended way for thresholds, if they want to work with size summation of matched entries
-	if check.HasThreshold("total_size") {
-		check.result.Metrics = append(check.result.Metrics,
-			&CheckMetric{
-				ThresholdName: "total_size",
-				Name:          "total_size",
-				Value:         totalSize,
-				Unit:          "B",
-				Warning:       check.warnThreshold,
-				Critical:      check.critThreshold,
-				Min:           &Zero,
-			})
-	}
+	check.result.Metrics = append(check.result.Metrics,
+		&CheckMetric{
+			ThresholdName: "total_size",
+			Name:          "total_size",
+			Value:         totalSize,
+			Unit:          "B",
+			Warning:       check.warnThreshold,
+			Critical:      check.critThreshold,
+			Min:           &Zero,
+		})
 
 	if check.HasThreshold("size") {
 		log.Warn("check_files - Using 'size' in a threshold argument meant to mean \"summation of all found files sizes\" is wrong. " +

--- a/pkg/snclient/check_files_linux_test.go
+++ b/pkg/snclient/check_files_linux_test.go
@@ -1,0 +1,59 @@
+package snclient
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckFilesPerfdataWhitespaceNames(t *testing.T) {
+	testDir, _ := os.Getwd()
+	scriptsDir := filepath.Join(testDir, "t", "scripts")
+	scriptName := "check_files_perfdata_generate_whitespace_files"
+	scriptFilename := scriptName
+
+	switch runtime.GOOS {
+	case "linux":
+		scriptFilename += ".sh"
+	default:
+		t.Skipf("Test is not intended to be run on %s", runtime.GOOS)
+	}
+
+	config := checkFilesTestConfigWithScript(t, scriptsDir, scriptName, scriptFilename)
+	snc := StartTestAgent(t, config)
+
+	// capture this since t.TempDir() is dyanic
+	geneartionDirectory := t.TempDir()
+
+	t.Logf("generationDirectory: %s", geneartionDirectory)
+
+	res := snc.RunCheck(scriptName, []string{geneartionDirectory})
+	assert.Equalf(t, CheckExitOK, res.State, "state matches")
+	outputString := string(res.BuildPluginOutput())
+	assert.Containsf(t, outputString, "ok - Generated 3 files for testing", "output matches")
+	assert.Containsf(t, outputString, "ok - Generated 0 directories for testing", "output matches")
+
+	// check_files_perfdata_generate_whitespace_files script generates a structure that looks like this
+	// The script should build a file tree that looks like this
+	// Files with whitespaces are allowed on linux filesystems
+	// .
+	// ├── ' '
+	// ├── '  '
+	// └── '   '
+	//
+	// 0 directories, 3 files
+
+	// Perfdata syntax for the file sizes are '<filename> size'
+	// Problem is that these would add "  size", "   size" and "    size" perfdata, which may be displayed as 'size' down the line
+	// These type of files hould be skipped when iterating
+
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "crit='size > 10Mb'", "crit='total_size > 10Mb'"})
+	outputString = string(res.BuildPluginOutput())
+	// This check includes the directories as well
+	assert.Containsf(t, outputString, "No files found |", "output matches")
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/check_files_test.go
+++ b/pkg/snclient/check_files_test.go
@@ -447,10 +447,15 @@ func TestCheckFilesSizePerfdata(t *testing.T) {
 	// 3 directories, 16 files
 
 	// Total size should be exactly 14 mb
-	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "crit='total_size > 100Mb'"})
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "crit='total_size > 20Mb'"})
 	outputString = string(res.BuildPluginOutput())
 	// This check includes the directories as well
 	assert.Containsf(t, outputString, "OK - All 18 files are ok", "output matches")
+
+	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "crit='total_size > 13Mb'"})
+	outputString = string(res.BuildPluginOutput())
+	assert.Containsf(t, outputString, "CRITICAL - 0/18 files", "output matches")
+	assert.Equal(t, CheckExitCritical, res.State)
 
 	res = snc.RunCheck("check_files", []string{"path=" + geneartionDirectory, "crit='total_size > 100Mb'", "filter='type == file'"})
 	outputString = string(res.BuildPluginOutput())

--- a/pkg/snclient/t/scripts/check_files_perfdata_generate_whitespace_files.sh
+++ b/pkg/snclient/t/scripts/check_files_perfdata_generate_whitespace_files.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script is intended to generate files to be tested for check_files
+# These files need to be generated dynamically, so they cant be simply saved in the repository.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TESTING_DIR="$1"
+
+mkdir -p "${TESTING_DIR}"
+
+(
+    cd "${TESTING_DIR}"
+
+    # Create files of 512KB (0.5MB)
+    dd if=/dev/zero of="${TESTING_DIR}/ " bs=1024 count=512 2>/dev/null
+    dd if=/dev/zero of="${TESTING_DIR}/  " bs=1024 count=512 2>/dev/null
+    dd if=/dev/zero of="${TESTING_DIR}/   " bs=1024 count=512 2>/dev/null
+
+    FILE_COUNT=$(find "${TESTING_DIR}" -type f -printf "." | wc -c)
+    echo "ok - Generated ${FILE_COUNT} files for testing"
+
+    DIRECTORY_COUNT=$(find "${TESTING_DIR}" -type d -printf "." | wc -c)
+    echo "ok - Generated $(( DIRECTORY_COUNT - 1 )) directories for testing"
+
+    if command -v tree >/dev/null 2>&1; then
+        echo "printing the tree of the files"
+        tree "${TESTING_DIR}"
+    else
+        echo "warning: tree command not found, skipping tree output"
+    fi
+)
+
+exit 0


### PR DESCRIPTION
linux allows files that have whitespaces in them. this can cause problems when the "<filename> size" perfdata is added, which could be displayed as "size" somwhere that trims the string. 

detect these files and skip them

append total_size metric always, without needing to have it inside a condition.

add small comments to the code