### PR TITLE
check_drivesize: accept drive argument if drive+seperator string equals the argument

### DIFF
--- a/pkg/snclient/check_drivesize_other.go
+++ b/pkg/snclient/check_drivesize_other.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/consol-monitoring/snclient/pkg/utils"
@@ -118,6 +119,13 @@ func (l *CheckDrivesize) setCustomPath(path string, requiredDisks map[string]map
 
 			break
 		}
+		if path == fmt.Sprintf("%s%c", vol["drive"], filepath.Separator) {
+			match = &vol
+
+			log.Debugf("Taking drive: '%s' for path: '%s' since it just needs a separator: '%c' at the end", vol["drive"], path, filepath.Separator)
+
+			break
+		}
 	}
 
 	if match != nil {
@@ -130,7 +138,7 @@ func (l *CheckDrivesize) setCustomPath(path string, requiredDisks map[string]map
 	// add anyway to generate an error later with more default values filled in
 	entry := l.driveEntry(path)
 	entry["_error"] = (&PartitionNotMountedError{
-		Path: path, err: fmt.Errorf("path :%s does exist, but could not match it to a drive. its likely that the partition is not mounted", path),
+		Path: path, err: fmt.Errorf("path :%s does exist, but could not match it to a drive. its likely that the partition does not exist or is not mounted", path),
 	}).Error()
 	requiredDisks[path] = entry
 

--- a/pkg/snclient/check_drivesize_other.go
+++ b/pkg/snclient/check_drivesize_other.go
@@ -122,7 +122,10 @@ func (l *CheckDrivesize) setCustomPath(path string, requiredDisks map[string]map
 		if path == fmt.Sprintf("%s%c", vol["drive"], filepath.Separator) {
 			match = &vol
 
-			log.Debugf("Taking drive: '%s' for path: '%s' since it just needs a separator: '%c' at the end", vol["drive"], path, filepath.Separator)
+			log.Debugf("For search path: '%s', taking drive: '%s' since adding a separator: '%s' matches the search path: '%s' ", path, vol["drive"], string(filepath.Separator), path)
+
+			// correct search path so that it looks uniform with the drivename in perfdata
+			path = strings.TrimSuffix(path, string(filepath.Separator))
 
 			break
 		}


### PR DESCRIPTION
example drive=/boot and drive=/boot/ to arguments both work now, previously it was only /boot

```
[18:23:38.361][D][check_drivesize_other:125] Taking drive: '/boot' for path: '/boot/' since it just needs a separator: '/' at the end
```

checked windows as it has its own setCustomPath function. It is already accepting all forms of the drive argument, no need to make changes

- c
- C
- c:
- C:
- c:\
- C:\
- c:/
- C:/