### PR TITLE
add additional flags to place 'count' and 'problem count' ~ 'failed' perfdata metrics to the front of metrics array.

### DIFF
--- a/pkg/snclient/check_service_linux.go
+++ b/pkg/snclient/check_service_linux.go
@@ -160,7 +160,9 @@ func (l *CheckService) Check(ctx context.Context, snc *Agent, check *CheckData, 
 
 	if len(l.services) == 0 && !check.showAll {
 		check.addCountMetrics = true
+		check.addCountMetricsToFront = true
 		check.addProblemCountMetrics = true
+		check.addProblemCountMetricsToFront = true
 	}
 
 	return check.Finalize()

--- a/pkg/snclient/check_service_linux.go
+++ b/pkg/snclient/check_service_linux.go
@@ -212,7 +212,10 @@ func (l *CheckService) addService(ctx context.Context, check *CheckData, service
 
 	check.listData = append(check.listData, listEntry)
 
-	l.addServiceMetrics(service, l.svcStateFloat(listEntry["state"]), check, listEntry)
+	// if the count is in a condition, we do not want to add services individually to perfdata
+	if !check.HasThreshold("count") {
+		l.addServiceMetrics(service, l.svcStateFloat(listEntry["state"]), check, listEntry)
+	}
 
 	return nil
 }

--- a/pkg/snclient/check_service_windows.go
+++ b/pkg/snclient/check_service_windows.go
@@ -262,7 +262,10 @@ func (l *CheckService) addService(ctx context.Context, check *CheckData, ctrlMgr
 
 	check.listData = append(check.listData, listEntry)
 
-	l.addServiceMetrics(service, float64(details.Status.State), check, listEntry)
+	// if the count is in a condition, we do not want to add services individually to perfdata
+	if !check.HasThreshold("count") {
+		l.addServiceMetrics(service, float64(details.Status.State), check, listEntry)
+	}
 
 	return nil
 }

--- a/pkg/snclient/check_service_windows.go
+++ b/pkg/snclient/check_service_windows.go
@@ -185,7 +185,9 @@ func (l *CheckService) Check(ctx context.Context, _ *Agent, check *CheckData, _ 
 
 	if len(l.services) == 0 && !check.showAll {
 		check.addCountMetrics = true
+		check.addCountMetricsToFront = true
 		check.addProblemCountMetrics = true
+		check.addProblemCountMetricsToFront = true
 	}
 
 	return check.Finalize()

--- a/pkg/snclient/checkdata.go
+++ b/pkg/snclient/checkdata.go
@@ -92,52 +92,54 @@ type CheckAttribute struct {
 
 // CheckData contains the runtime data of a generic check plugin
 type CheckData struct {
-	noCopy                 noCopy
-	name                   string
-	description            string
-	docTitle               string
-	usage                  string
-	defaultFilter          string
-	conditionAlias         map[string]map[string]string // replacement map of equivalent condition values
-	conditionColAlias      map[string][]string          // if there are filter for given column, apply to alias columns too
-	args                   map[string]CheckArgument
-	extraArgs              map[string]CheckArgument // internal, map of expanded args
-	argsPassthrough        bool                     // allow arbitrary arguments without complaining about unknown argument
-	hasArgsSupplied        map[string]bool          // map which is true if a arg has been specified on the command line
-	rawArgs                []string
-	filter                 ConditionList // if set, only show entries matching this filter set
-	warnThreshold          ConditionList
-	defaultWarning         string
-	critThreshold          ConditionList
-	defaultCritical        string
-	okThreshold            ConditionList
-	detailSyntax           string
-	topSyntax              string
-	okSyntax               string
-	hasArgsFilter          bool // will be true if any arg supplied which has isFilter set
-	emptySyntax            string
-	emptyState             int64
-	emptyStateSet          bool
-	details                map[string]string
-	listData               []map[string]string
-	listCombine            string // join string for detail list
-	listCombineSet         bool   // has the listCombine been set by user
-	showAll                bool   // flag if check called with show-all
-	addCountMetrics        bool
-	addProblemCountMetrics bool
-	result                 *CheckResult
-	showHelp               ShowHelp
-	timeout                float64 // timeout in seconds
-	perfConfig             []PerfConfig
-	perfSyntax             string
-	hasInventory           InventoryMode
-	output                 OutputMode
-	implemented            Implemented
-	attributes             []CheckAttribute
-	listSorted             []string // sort result list by this keys
-	exampleDefault         string
-	exampleArgs            string
-	timezone               *time.Location // timezone used for date output set by --timezone
+	noCopy                        noCopy
+	name                          string
+	description                   string
+	docTitle                      string
+	usage                         string
+	defaultFilter                 string
+	conditionAlias                map[string]map[string]string // replacement map of equivalent condition values
+	conditionColAlias             map[string][]string          // if there are filter for given column, apply to alias columns too
+	args                          map[string]CheckArgument
+	extraArgs                     map[string]CheckArgument // internal, map of expanded args
+	argsPassthrough               bool                     // allow arbitrary arguments without complaining about unknown argument
+	hasArgsSupplied               map[string]bool          // map which is true if a arg has been specified on the command line
+	rawArgs                       []string
+	filter                        ConditionList // if set, only show entries matching this filter set
+	warnThreshold                 ConditionList
+	defaultWarning                string
+	critThreshold                 ConditionList
+	defaultCritical               string
+	okThreshold                   ConditionList
+	detailSyntax                  string
+	topSyntax                     string
+	okSyntax                      string
+	hasArgsFilter                 bool // will be true if any arg supplied which has isFilter set
+	emptySyntax                   string
+	emptyState                    int64
+	emptyStateSet                 bool
+	details                       map[string]string
+	listData                      []map[string]string
+	listCombine                   string // join string for detail list
+	listCombineSet                bool   // has the listCombine been set by user
+	showAll                       bool   // flag if check called with show-all
+	addCountMetrics               bool
+	addCountMetricsToFront        bool
+	addProblemCountMetrics        bool
+	addProblemCountMetricsToFront bool
+	result                        *CheckResult
+	showHelp                      ShowHelp
+	timeout                       float64 // timeout in seconds
+	perfConfig                    []PerfConfig
+	perfSyntax                    string
+	hasInventory                  InventoryMode
+	output                        OutputMode
+	implemented                   Implemented
+	attributes                    []CheckAttribute
+	listSorted                    []string // sort result list by this keys
+	exampleDefault                string
+	exampleArgs                   string
+	timezone                      *time.Location // timezone used for date output set by --timezone
 }
 
 func (cd *CheckData) Finalize() (*CheckResult, error) {
@@ -388,29 +390,36 @@ func (cd *CheckData) buildListMacrosFromSingleEntry() map[string]string {
 }
 
 func (cd *CheckData) buildCountMetrics(listLen, critLen, warnLen int) {
-	if cd.addCountMetrics {
-		cd.result.Metrics = append(
-			cd.result.Metrics,
-			&CheckMetric{
-				Name:     "count",
-				Value:    listLen,
-				Warning:  cd.warnThreshold,
-				Critical: cd.critThreshold,
-				Min:      &Zero,
-			},
-		)
-	}
+	// prepending is slower, so keep separate flags for adding to front
+
 	if cd.addProblemCountMetrics {
-		cd.result.Metrics = append(
-			cd.result.Metrics,
-			&CheckMetric{
-				Name:     "failed",
-				Value:    critLen + warnLen,
-				Warning:  cd.warnThreshold,
-				Critical: cd.critThreshold,
-				Min:      &Zero,
-			},
-		)
+		metric := &CheckMetric{
+			Name:     "failed",
+			Value:    critLen + warnLen,
+			Warning:  cd.warnThreshold,
+			Critical: cd.critThreshold,
+			Min:      &Zero,
+		}
+		if cd.addProblemCountMetricsToFront {
+			cd.result.Metrics = append([]*CheckMetric{metric}, cd.result.Metrics...)
+		} else {
+			cd.result.Metrics = append(cd.result.Metrics, metric)
+		}
+	}
+
+	if cd.addCountMetrics {
+		metric := &CheckMetric{
+			Name:     "count",
+			Value:    listLen,
+			Warning:  cd.warnThreshold,
+			Critical: cd.critThreshold,
+			Min:      &Zero,
+		}
+		if cd.addCountMetricsToFront {
+			cd.result.Metrics = append([]*CheckMetric{metric}, cd.result.Metrics...)
+		} else {
+			cd.result.Metrics = append(cd.result.Metrics, metric)
+		}
 	}
 }
 


### PR DESCRIPTION
this flag is for CheckData struct, so it can be used alongside any other check that utilizes addCountMetrics.

existing: addCountMetrics
added: addCountMetricsToFront
existing: addProblemCountMetrics
added: addProblemCountMetricsToFront

prepending is slower than appending if its a long list, so its a flag. behavior is opt-in and not default.

toggle this flag for check_service, this was the intended target for this. when each service has its own perfdata metric, which could be above 100 metrics total, the count would be appended to the end and truncated in previews.

```
./snclient run check_service warn="count gt 10"
WARNING - found 75 services |'count'=75;10;;0 'failed'=0;;;0 'acpid'=4 'apache2'=4 'apparmor'=3 ......
```