### PR TITLE
check_tasksched: allow more ntfs characters like space,dash,parantheses etc. in the folder to be searched. quotes are not allowed

### DIFF
--- a/pkg/snclient/check_tasksched_windows.go
+++ b/pkg/snclient/check_tasksched_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -36,8 +37,10 @@ func (l *CheckTasksched) addTasks(ctx context.Context, snc *Agent, check *CheckD
 	}
 
 	if l.Folder != CheckTaskschedDefaultFolder {
-		if strings.ContainsFunc(l.Folder, func(r rune) bool { return !unicode.IsLetter(r) && r != '\\' }) {
-			return fmt.Errorf("custom specified folder should be all letters or backslashes, but it isnt: %s", l.Folder)
+		// NTFS characters are generally allowed, expect quotes
+		allowedRunes := []rune{' ', '-', '\\', '_', '(', ')', '[', ']', '.', ','}
+		if strings.ContainsFunc(l.Folder, func(r rune) bool { return !unicode.IsLetter(r) && !slices.Contains(allowedRunes, r) }) {
+			return fmt.Errorf("custom specified folder should be all letters or allowed runes: '%s', but it isnt: %s", string(allowedRunes), l.Folder)
 		}
 	}
 

--- a/pkg/snclient/snclient_windows.go
+++ b/pkg/snclient/snclient_windows.go
@@ -406,7 +406,7 @@ func powerShellCmd(ctx context.Context, command string, parameters ...PowerShell
 	cmd = exec.CommandContext(ctx, "powershell")
 	cmd.Args = nil
 
-	checkQuoutes := func(str string) bool {
+	checkQuotes := func(str string) bool {
 		if strings.ContainsRune(str, '\'') || strings.ContainsRune(str, '"') {
 			return true
 		}
@@ -414,9 +414,9 @@ func powerShellCmd(ctx context.Context, command string, parameters ...PowerShell
 		return false
 	}
 	for _, para := range parameters {
-		if checkQuoutes(para.name) || checkQuoutes(para.parameterType) ||
-			checkQuoutes(para.defaultValue) || checkQuoutes(para.specifiedValue) {
-			return nil, errors.New("one of the parameters has its name/type or values contain single or double quoutes")
+		if checkQuotes(para.name) || checkQuotes(para.parameterType) ||
+			checkQuotes(para.defaultValue) || checkQuotes(para.specifiedValue) {
+			return nil, errors.New("one of the parameters has its name/type or values contain single or double quotes")
 		}
 	}
 


### PR DESCRIPTION
check_tasksched: allow more ntfs characters like space,dash,parantheses etc. in the folder to be searched. quotes are not allowed

fix typo in powerShellCmd function definition -> checkQuoutes should be checkQuotes