### PR TITLE
Devuan compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,7 @@ deb: | dist
 		build-deb/usr/lib/systemd/system \
 		build-deb/usr/lib/sysusers.d \
 		build-deb/usr/lib/tmpfiles.d \
+		build-deb/etc/init.d \
 		build-deb/etc/logrotate.d \
 		build-deb/usr/share/doc/snclient \
 		build-deb/usr/share/doc/snclient \
@@ -482,6 +483,7 @@ deb: | dist
 	cp ./packaging/snclient.service build-deb/usr/lib/systemd/system/
 	cp ./packaging/snclient.sysusers build-deb/usr/lib/sysusers.d/snclient.conf
 	cp ./packaging/snclient.tmpfiles build-deb/usr/lib/tmpfiles.d/snclient.conf
+	cp ./packaging/debian-snclient-initd build-deb/etc/init.d/snclient
 	cp ./packaging/snclient.logrotate build-deb/etc/logrotate.d/snclient
 	cp Changes build-deb/usr/share/doc/snclient/Changes
 	dch --empty --create --newversion "$(VERSION)" --package "snclient" -D "UNRELEASED" --urgency "low" -c build-deb/usr/share/doc/snclient/changelog "new upstream release"

--- a/Makefile
+++ b/Makefile
@@ -459,9 +459,9 @@ deb: | dist
 		build-deb/etc/snclient \
 		build-deb/usr/lib/snclient \
 		build-deb/usr/bin \
-		build-deb/lib/systemd/system \
-		build-deb/lib/sysusers.d \
-		build-deb/lib/tmpfiles.d \
+		build-deb/usr/lib/systemd/system \
+		build-deb/usr/lib/sysusers.d \
+		build-deb/usr/lib/tmpfiles.d \
 		build-deb/etc/logrotate.d \
 		build-deb/usr/share/doc/snclient \
 		build-deb/usr/share/doc/snclient \
@@ -479,9 +479,9 @@ deb: | dist
 	cp -r ./packaging/debian ./build-deb/DEBIAN
 	cp ./dist/snclient.ini ./dist/server.crt ./dist/server.key ./dist/cacert.pem ./build-deb/etc/snclient
 	cp -p ./dist/snclient build-deb/usr/bin/snclient
-	cp ./packaging/snclient.service build-deb/lib/systemd/system/
-	cp ./packaging/snclient.sysusers build-deb/lib/sysusers.d/snclient.conf
-	cp ./packaging/snclient.tmpfiles build-deb/lib/tmpfiles.d/snclient.conf
+	cp ./packaging/snclient.service build-deb/usr/lib/systemd/system/
+	cp ./packaging/snclient.sysusers build-deb/usr/lib/sysusers.d/snclient.conf
+	cp ./packaging/snclient.tmpfiles build-deb/usr/lib/tmpfiles.d/snclient.conf
 	cp ./packaging/snclient.logrotate build-deb/etc/logrotate.d/snclient
 	cp Changes build-deb/usr/share/doc/snclient/Changes
 	dch --empty --create --newversion "$(VERSION)" --package "snclient" -D "UNRELEASED" --urgency "low" -c build-deb/usr/share/doc/snclient/changelog "new upstream release"

--- a/packaging/debian-snclient-initd
+++ b/packaging/debian-snclient-initd
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          snclient
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Should-Start:      $network $syslog
+# Should-Stop:       $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: SNClient monitoring agent
+# Description:       SNClient monitoring agent
+### END INIT INFO
+
+test -f /usr/bin/snclient || exit 0
+
+. /lib/lsb/init-functions
+
+DAEMON=/usr/bin/snclient
+PIDFILE=/run/snclient/snclient.pid
+NAME=snclient
+DESC="SNClient monitoring agent"
+
+DAEMON_ARGS="--config ${SNCLIENT_CONFIG_FILE:-/etc/snclient/snclient.ini} daemon --pidfile $PIDFILE"
+
+START_STOP_ARGS="--pidfile $PIDFILE --exec $DAEMON"
+START_ARGS="--chuid ${SNCLIENT_USER:-snclient}"
+
+RELOAD_SIGNAL=HUP
+
+export LC_ALL=C
+export LC_LANG=C
+
+check_config() {
+	snclient config check -q || exit 1
+}
+
+do_start() {
+	mkdir -p /run/snclient
+	chown snclient /run/snclient
+	start-stop-daemon --start --oknodo --quiet $START_STOP_ARGS $START_ARGS -- $DAEMON_ARGS >/dev/null
+}
+
+case "$1" in
+	start)
+		echo -n "Starting $DESC: "
+		check_config
+		do_start
+		echo "$NAME."
+		;;
+	stop)
+		echo -n "Stopping $DESC: "
+		start-stop-daemon --stop --oknodo --quiet $START_STOP_ARGS
+		echo "$NAME."
+		;;
+	restart|force-reload)
+		echo -n "Restarting $DESC: "
+		check_config
+		start-stop-daemon --stop --oknodo --quiet $START_STOP_ARGS
+		sleep 1
+		do_start
+		echo "$NAME."
+		;;
+	reload)
+		echo -n "Reloading $DESC: "
+		check_config
+		start-stop-daemon --stop --signal $RELOAD_SIGNAL --quiet $START_STOP_ARGS
+		echo "$NAME."
+		;;
+	status)
+		status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+		;;
+	*)
+		N=/etc/init.d/$NAME
+		echo "Usage: $N {start|stop|restart|reload|force-reload|status}" >&2
+		exit 1
+		;;
+esac
+
+exit 0
+		
+		
+	

--- a/packaging/debian/conffiles
+++ b/packaging/debian/conffiles
@@ -2,4 +2,5 @@
 /etc/snclient/server.crt
 /etc/snclient/server.key
 /etc/snclient/cacert.pem
+/etc/init.d/snclient
 /etc/logrotate.d/snclient

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,8 @@ Version: UNSET
 Section: net
 Priority: optional
 Architecture: UNSET
-Depends: logrotate, systemd
+Pre-Depends: init-system-helpers (>= 1.54~)
+Depends: logrotate, adduser
 Standards-Version: 3.9.8
 Suggests: monitoring-plugins-basic
 Maintainer: Sven Nierlein <sven@consol.de>

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -15,11 +15,30 @@ case "$1" in
         || :
       if [ -x "/usr/bin/systemd-sysusers" ]; then
           systemd-sysusers
+      else
+          # Create snclient group if it doesn't exist
+          if ! getent group snclient >/dev/null; then
+            addgroup -S snclient
+          fi
+
+          # Create snclient user if it doesn't exist
+          if ! getent passwd snclient >/dev/null; then
+            adduser -S -D -H -h /var/lib/snclient -s /sbin/nologin -G snclient -g "Secure Naemon Client" snclient
+          fi
       fi
       if [ -x "/usr/bin/systemd-tmpfiles" ]; then
           systemd-tmpfiles --create
+      else
+          # Create and set permissions on directories
+          install -d -m 0755 -o snclient -g snclient /etc/snclient
+          install -d -m 0755 -o snclient -g snclient /var/lib/snclient
+          install -d -m 0755 -o snclient -g snclient /var/log/snclient
+
+          # Fix ownership of config files
+          # This throws a lintian warning, though /etc/snclient already had pretty restrictive permissions to begin with
+          chown -R snclient:snclient /etc/snclient
       fi
-      if [ -x "/usr/bin/deb-systemd-helper" ]; then
+      if [ -x "/usr/bin/deb-systemd-helper" ] && [ -x "/usr/bin/systemctl" ] ; then
         deb-systemd-helper unmask snclient.service
         if deb-systemd-helper --quiet was-enabled snclient.service; then
           deb-systemd-helper enable snclient.service
@@ -35,8 +54,11 @@ case "$1" in
         setcap "cap_setuid,cap_setgid+ep" /usr/bin/snclient || true
       fi
 
-      systemctl --system daemon-reload >/dev/null 2>&1 || true
-      deb-systemd-invoke start snclient
+      if [ -x "/usr/bin/systemctl" ] ; then
+        systemctl --system daemon-reload >/dev/null 2>&1 || true
+        deb-systemd-invoke start snclient
+      fi
+      update-rc.d snclient defaults
     ;;
 
     abort-remove|abort-deconfigure)

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,3 +1,9 @@
 #!/bin/sh
 set -e
-systemctl --system daemon-reload >/dev/null 2>&1 || true
+if [ -x "/usr/bin/systemctl" ] ; then
+	systemctl --system daemon-reload >/dev/null 2>&1 || true
+fi
+
+if [ "$1" = "purge" ] ; then
+	update-rc.d snclient remove
+fi

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,3 +1,7 @@
 #!/bin/sh
 set -e
-deb-systemd-invoke stop snclient || :
+if [ -x "/usr/bin/deb-systemd-invoke" ] && [ -x "/usr/bin/systemctl" ] ; then
+	deb-systemd-invoke stop snclient || :
+elif [ -x "/usr/sbin/rc-service" ] ; then
+	rc-service -q snclient stop || :
+fi


### PR DESCRIPTION
This PR makes the debian package installable without systemd so it works under devuan too.

It also adds an init.d service file that uses the `start-stop-daemon` that should just work™ on devuan without adding additional dependencies for debian.

Fixes #396 