### PR TITLE
Add support for armv7

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux, freebsd]
-        go-arch: [i386, x86_64, aarch64, armv7l]
+        go-arch: [i386, x86_64, aarch64, armv7]
         exclude:
           - go-os: freebsd
-            go-arch: armv7l
+            go-arch: armv7
     needs: [get-version]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -42,7 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux, freebsd]
-        go-arch: [i386, x86_64, aarch64]
+        go-arch: [i386, x86_64, aarch64, armv7l]
+        exclude:
+          - go-os: freebsd
+            go-arch: armv7l
     needs: [get-version]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -118,10 +118,10 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux, freebsd]
-        go-arch: [i386, x86_64, aarch64, armv7l]
+        go-arch: [i386, x86_64, aarch64, armv7]
         exclude:
           - go-os: freebsd
-            go-arch: armv7l
+            go-arch: armv7
     needs: [get-version]
     runs-on: ubuntu-latest
     env:
@@ -378,7 +378,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64, armv7l]
+        go-arch: [i386, x86_64, aarch64, armv7]
     runs-on: ubuntu-latest
     needs: [get-version, build, dist-linux-osx]
     env:
@@ -611,7 +611,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64, armv7l]
+        go-arch: [i386, x86_64, aarch64, armv7]
     runs-on: ubuntu-latest
     needs: [get-version,pkg-rpm,pkg-deb]
     env:
@@ -782,7 +782,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64, armv7l]
+        go-arch: [i386, x86_64, aarch64, armv7]
     runs-on: ubuntu-latest
     needs: [get-version,make-release]
     permissions:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -118,7 +118,10 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux, freebsd]
-        go-arch: [i386, x86_64, aarch64]
+        go-arch: [i386, x86_64, aarch64, armv7l]
+        exclude:
+          - go-os: freebsd
+            go-arch: armv7l
     needs: [get-version]
     runs-on: ubuntu-latest
     env:
@@ -375,7 +378,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64]
+        go-arch: [i386, x86_64, aarch64, armv7l]
     runs-on: ubuntu-latest
     needs: [get-version, build, dist-linux-osx]
     env:
@@ -608,7 +611,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64]
+        go-arch: [i386, x86_64, aarch64, armv7l]
     runs-on: ubuntu-latest
     needs: [get-version,pkg-rpm,pkg-deb]
     env:
@@ -779,7 +782,7 @@ jobs:
       fail-fast: false
       matrix:
         go-os: [linux]
-        go-arch: [i386, x86_64, aarch64]
+        go-arch: [i386, x86_64, aarch64, armv7l]
     runs-on: ubuntu-latest
     needs: [get-version,make-release]
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,17 @@ endif
 ifeq ($(GOARCH),aarch64)
 	export GOARCH := arm64
 endif
+ifeq ($(GOARCH),armv7l)
+	export GOARCH := arm
+	export GOARM := 7
+endif
 
 DEB_ARCH:=$(GOARCH)
 ifeq ($(DEB_ARCH),386)
 	DEB_ARCH := i386
+endif
+ifeq ($(DEB_ARCH),arm)
+	DEB_ARCH := armhf
 endif
 DEBFILE ?= snclient-$(VERSION)-$(RPM_ARCH).deb
 
@@ -58,8 +65,13 @@ GITBASE=github.com/consol-monitoring/snclient
 BUILD_FLAGS=-ldflags "-s -w -X $(GITBASE)/pkg/snclient.Build=$(BUILD) -X $(GITBASE)/pkg/snclient.Revision=$(REVISION)"
 TEST_FLAGS=-timeout=5m $(BUILD_FLAGS)
 
+NODE_EXPORTER_ARCH:=$(GOARCH)
+ifeq ($(NODE_EXPORTER_ARCH),arm)
+	NODE_EXPORTER_ARCH := armv7
+endif
+
 NODE_EXPORTER_VERSION=1.11.1
-NODE_EXPORTER_FILE=node_exporter-$(NODE_EXPORTER_VERSION).$(GOOS)-$(GOARCH).tar.gz
+NODE_EXPORTER_FILE=node_exporter-$(NODE_EXPORTER_VERSION).$(GOOS)-$(NODE_EXPORTER_ARCH).tar.gz
 NODE_EXPORTER_URL=https://github.com/prometheus/node_exporter/releases/download/v$(NODE_EXPORTER_VERSION)
 
 # last i386 exe is the 0.24.0
@@ -472,8 +484,8 @@ deb: | dist
 	test -f $(NODE_EXPORTER_FILE) || curl -s -L -O $(NODE_EXPORTER_URL)/$(NODE_EXPORTER_FILE)
 	shasum --ignore-missing -c packaging/sha256sums.txt
 	tar zxvf $(NODE_EXPORTER_FILE)
-	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)/node_exporter build-deb/usr/lib/snclient/node_exporter
-	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)
+	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)/node_exporter build-deb/usr/lib/snclient/node_exporter
+	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)
 
 	rm -rf ./build-deb/DEBIAN
 	cp -r ./packaging/debian ./build-deb/DEBIAN
@@ -523,8 +535,8 @@ rpm: | dist
 	test -f $(NODE_EXPORTER_FILE) || curl -s -L -O $(NODE_EXPORTER_URL)/$(NODE_EXPORTER_FILE)
 	shasum --ignore-missing -c packaging/sha256sums.txt
 	tar zxvf $(NODE_EXPORTER_FILE)
-	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)/node_exporter snclient-$(VERSION)/node_exporter
-	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)
+	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)/node_exporter snclient-$(VERSION)/node_exporter
+	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)
 
 	chmod 755 \
 		snclient-$(VERSION)/snclient \
@@ -560,8 +572,8 @@ apk: | dist
 
 	test -f $(NODE_EXPORTER_FILE) || curl -s -L -O $(NODE_EXPORTER_URL)/$(NODE_EXPORTER_FILE)
 	tar zxvf $(NODE_EXPORTER_FILE)
-	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)/node_exporter snclient-$(VERSION)/node_exporter
-	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(GOARCH)
+	mv node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)/node_exporter snclient-$(VERSION)/node_exporter
+	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).linux-$(NODE_EXPORTER_ARCH)
 
 	chmod 755 \
 		snclient-$(VERSION)/snclient \
@@ -589,9 +601,9 @@ osx: | dist
 	test -f $(NODE_EXPORTER_FILE) || curl -s -L -O $(NODE_EXPORTER_URL)/$(NODE_EXPORTER_FILE)
 	shasum --ignore-missing -c packaging/sha256sums.txt
 	tar zxvf $(NODE_EXPORTER_FILE)
-	mv node_exporter-$(NODE_EXPORTER_VERSION).darwin-$(GOARCH)/node_exporter build-pkg/usr/local/bin/node_exporter
+	mv node_exporter-$(NODE_EXPORTER_VERSION).darwin-$(NODE_EXPORTER_ARCH)/node_exporter build-pkg/usr/local/bin/node_exporter
 	chmod 755 build-pkg/usr/local/bin/node_exporter
-	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).darwin-$(GOARCH)
+	rm -rf node_exporter-$(NODE_EXPORTER_VERSION).darwin-$(NODE_EXPORTER_ARCH)
 
 	cp packaging/osx/com.snclient.snclient.plist build-pkg/Library/LaunchDaemons/
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 ifeq ($(GOARCH),aarch64)
 	export GOARCH := arm64
 endif
-ifeq ($(GOARCH),armv7l)
+ifeq ($(GOARCH),armv7)
 	export GOARCH := arm
 	export GOARM := 7
 endif
@@ -65,10 +65,8 @@ GITBASE=github.com/consol-monitoring/snclient
 BUILD_FLAGS=-ldflags "-s -w -X $(GITBASE)/pkg/snclient.Build=$(BUILD) -X $(GITBASE)/pkg/snclient.Revision=$(REVISION)"
 TEST_FLAGS=-timeout=5m $(BUILD_FLAGS)
 
-NODE_EXPORTER_ARCH:=$(GOARCH)
-ifeq ($(NODE_EXPORTER_ARCH),arm)
-	NODE_EXPORTER_ARCH := armv7
-endif
+# node_exporter expects armv7, not arm
+NODE_EXPORTER_ARCH=$(GOARCH:arm=armv7)
 
 NODE_EXPORTER_VERSION=1.11.1
 NODE_EXPORTER_FILE=node_exporter-$(NODE_EXPORTER_VERSION).$(GOOS)-$(NODE_EXPORTER_ARCH).tar.gz
@@ -847,5 +845,6 @@ updatenodeexportersums:
 	grep linux-386.tar.gz    sha256sums_node_exporter.txt >> sha256sums.txt
 	grep linux-amd64.tar.gz  sha256sums_node_exporter.txt >> sha256sums.txt
 	grep linux-arm64.tar.gz  sha256sums_node_exporter.txt >> sha256sums.txt
+	grep linux-armv7.tar.gz  sha256sums_node_exporter.txt >> sha256sums.txt
 	mv sha256sums.txt packaging/sha256sums.txt
 	rm -f sha256sums_node_exporter.txt

--- a/packaging/sha256sums.txt
+++ b/packaging/sha256sums.txt
@@ -6,3 +6,4 @@ e987428618362c2d2540a68b722bd982ef1486c9961631298f20ea8fd57d3be4  node_exporter-
 4df4ec0dca5bc061c59181cfedcd8887cb5df9c710db3c4038bc51923414bc5d  node_exporter-1.11.1.linux-386.tar.gz
 9f5ea48e5bc7b656f8a91a32e7d7deb89f70f73dabd0d974418aca15f37d6810  node_exporter-1.11.1.linux-amd64.tar.gz
 ba1886efbd76cb96b0087c695ea8d1b9cb6e8aa946c996d744e9ee16c8e3591a  node_exporter-1.11.1.linux-arm64.tar.gz
+661c662e566d5c68950d63f7dfd1ec46ba28858f91aeba220c32baa1d3ad7b33  node_exporter-1.11.1.linux-armv7.tar.gz


### PR DESCRIPTION
Tested the binary itself + installing the .deb package (node_exporter works aswell)

```
Architecture:              armv7l
Byte Order:                Little Endian
Vendor ID:                 ARM
Model name:                Cortex-A53

PRETTY_NAME="Raspbian GNU/Linux 12 (bookworm)"
NAME="Raspbian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=raspbian
ID_LIKE=debian
```

```
$ curl http://127.77.1.1:5758/metrics
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
...
```