### PR TITLE
Fix cache allowed hosts condition

### DIFF
--- a/pkg/snclient/allowed_host.go
+++ b/pkg/snclient/allowed_host.go
@@ -44,6 +44,8 @@ func NewAllowedHostConfig(conf *ConfigSection) (*AllowedHostConfig, error) {
 	return ahc, nil
 }
 
+// Checks if remoteAddr is in allowed hosts
+// Accepts both IPv4 and IPv6
 func (ahc *AllowedHostConfig) Check(ctx context.Context, remoteAddr string) bool {
 	if len(ahc.Allowed) == 0 {
 		return true
@@ -88,6 +90,7 @@ func (ahc *AllowedHostConfig) Debug() {
 	}
 }
 
+// Represents an item in the allowed hosts list, can be an hostname, IP or IP prefix
 type AllowedHost struct {
 	Prefix       *netip.Prefix
 	IP           *netip.Addr
@@ -143,13 +146,16 @@ func (a *AllowedHost) Contains(ctx context.Context, addr netip.Addr, useCaching 
 	case a.IP != nil:
 		return a.IP.Compare(addr) == 0
 	case a.HostName != nil:
-		resolved := a.ResolveCache
+		var resolved []netip.Addr
 
-		if useCaching || len(a.ResolveCache) == 0 {
+		if !useCaching || len(a.ResolveCache) == 0 {
 			resolved = a.resolveCache(ctx)
+
 			if useCaching {
 				a.ResolveCache = resolved
 			}
+		} else {
+			resolved = a.ResolveCache
 		}
 
 		for _, i := range resolved {

--- a/pkg/snclient/allowed_host.go
+++ b/pkg/snclient/allowed_host.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/netip"
 	"strings"
+	"sync"
 )
 
 type AllowedHostConfig struct {
@@ -92,10 +93,11 @@ func (ahc *AllowedHostConfig) Debug() {
 
 // Represents an item in the allowed hosts list, can be an hostname, IP or IP prefix
 type AllowedHost struct {
-	Prefix       *netip.Prefix
-	IP           *netip.Addr
-	HostName     *string
-	ResolveCache []netip.Addr
+	Prefix            *netip.Prefix
+	IP                *netip.Addr
+	HostName          *string
+	ResolveCacheMutex *sync.RWMutex
+	ResolveCache      []netip.Addr
 }
 
 func NewAllowedHost(name string) AllowedHost {
@@ -122,6 +124,7 @@ func NewAllowedHost(name string) AllowedHost {
 	}
 
 	allowed.HostName = &name
+	allowed.ResolveCacheMutex = &sync.RWMutex{}
 
 	return allowed
 }
@@ -148,14 +151,19 @@ func (a *AllowedHost) Contains(ctx context.Context, addr netip.Addr, useCaching 
 	case a.HostName != nil:
 		var resolved []netip.Addr
 
+		a.ResolveCacheMutex.RLock()
 		if !useCaching || len(a.ResolveCache) == 0 {
+			a.ResolveCacheMutex.RUnlock()
 			resolved = a.resolveCache(ctx)
 
 			if useCaching {
+				a.ResolveCacheMutex.Lock()
 				a.ResolveCache = resolved
+				a.ResolveCacheMutex.Unlock()
 			}
 		} else {
 			resolved = a.ResolveCache
+			a.ResolveCacheMutex.RUnlock()
 		}
 
 		for _, i := range resolved {


### PR DESCRIPTION
two fixes:

fix if-else branch that checks if host cache is disabled or unpopulated

use a rw mutex for the resolvecache
    
AllowedHost.ResolveCache is populated lazily and not ahead of time during construction. In a race condition, multiple writes can overwrite eachother.
    
if multiple connections are being established at the same time, which happens in different goroutines,  they can run AllowedHost.Contains at the same time as well and overwrite the ResolveCache

resolves #406