### PR TITLE
packaging: add systemd memory limit as last resort

### DIFF
--- a/packaging/snclient.service
+++ b/packaging/snclient.service
@@ -9,6 +9,16 @@ Group=snclient
 
 AmbientCapabilities=CAP_SETUID CAP_SETGID
 
+# Last-resort protection for the complete service cgroup, including child
+# processes. The in-process 512 MiB RSS watcher remains the primary safeguard.
+MemoryAccounting=yes
+MemoryHigh=1536M
+MemoryMax=2G
+
+# Treat a cgroup OOM as a failure of the complete service and restart cleanly.
+OOMPolicy=kill
+KillMode=control-group
+
 Restart=on-failure
 RestartSec=10
 


### PR DESCRIPTION
Complement ba98889 with an outer hard limit in case the internal RSS watcher does not take effect. The cgroup-wide limit also covers external scripts spawned by SNClient.

`OOMPolicy=kill` is intentional: reaching the outer 2 GiB limit indicates an exceptional condition in the service cgroup. Terminating and restarting the complete service provides a clean and predictable recovery instead of leaving the agent running after an arbitrary process has been selected by the OOM killer.
