### PR TITLE
fix MSI upgrade hanging due to service not stopped before file removal

### DIFF
--- a/packaging/windows/snclient.wxs
+++ b/packaging/windows/snclient.wxs
@@ -15,7 +15,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Name="SNClient" Id="*" UpgradeCode="F4BF03F6-D3DA-44FF-A444-9B64119DA0CE" Language="1033" Codepage="1252" Version="$(var.MajorVersion).$(var.MinorVersion).$(var.RevisionNumber)" Manufacturer="ConSol Consulting and Solutions Software GmbH">
         <Package InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" Compressed="yes" />
-        <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
+        <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallExecute" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
         <Property Id="REBOOT" Value="ReallySuppress" />
         <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
@@ -99,7 +99,7 @@
         <SetProperty Id="CustomUnInstallerAction" Sequence="execute" Before="CustomUnInstallerAction" Value="&quot;[INSTALLDIR]snclient.exe&quot; uninstall pkg &quot;INSTALLDIR=[INSTALLDIR]; WIX_UPGRADE_DETECTED=[WIX_UPGRADE_DETECTED]; REMOVE=[REMOVE]; UPGRADINGPRODUCTCODE=[UPGRADINGPRODUCTCODE]&quot;" />
         <CustomAction Id="CustomUnInstallerAction" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
         <InstallExecuteSequence>
-            <Custom Action="CustomPreUpdateAction" Before="RemoveExistingProducts"></Custom>
+            <Custom Action="CustomPreUpdateAction" After="InstallInitialize"></Custom>
             <Custom Action="CustomUnInstallerAction" Before="RemoveFiles"><![CDATA[REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)]]></Custom>
             <Custom Action="CustomInstallerAction" Before="InstallFinalize"></Custom>
         </InstallExecuteSequence>

--- a/packaging/windows/snclient.wxs
+++ b/packaging/windows/snclient.wxs
@@ -99,7 +99,7 @@
         <SetProperty Id="CustomUnInstallerAction" Sequence="execute" Before="CustomUnInstallerAction" Value="&quot;[INSTALLDIR]snclient.exe&quot; uninstall pkg &quot;INSTALLDIR=[INSTALLDIR]; WIX_UPGRADE_DETECTED=[WIX_UPGRADE_DETECTED]; REMOVE=[REMOVE]; UPGRADINGPRODUCTCODE=[UPGRADINGPRODUCTCODE]&quot;" />
         <CustomAction Id="CustomUnInstallerAction" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
         <InstallExecuteSequence>
-            <Custom Action="CustomPreUpdateAction" After="InstallInitialize" Before="RemoveExistingProducts"></Custom>
+            <Custom Action="CustomPreUpdateAction" Before="RemoveExistingProducts"></Custom>
             <Custom Action="CustomUnInstallerAction" Before="RemoveFiles"><![CDATA[REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)]]></Custom>
             <Custom Action="CustomInstallerAction" Before="InstallFinalize"></Custom>
         </InstallExecuteSequence>

--- a/packaging/windows/snclient.wxs
+++ b/packaging/windows/snclient.wxs
@@ -15,7 +15,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Name="SNClient" Id="*" UpgradeCode="F4BF03F6-D3DA-44FF-A444-9B64119DA0CE" Language="1033" Codepage="1252" Version="$(var.MajorVersion).$(var.MinorVersion).$(var.RevisionNumber)" Manufacturer="ConSol Consulting and Solutions Software GmbH">
         <Package InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" Compressed="yes" />
-        <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallExecute" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
+        <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
         <Property Id="REBOOT" Value="ReallySuppress" />
         <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
@@ -99,7 +99,7 @@
         <SetProperty Id="CustomUnInstallerAction" Sequence="execute" Before="CustomUnInstallerAction" Value="&quot;[INSTALLDIR]snclient.exe&quot; uninstall pkg &quot;INSTALLDIR=[INSTALLDIR]; WIX_UPGRADE_DETECTED=[WIX_UPGRADE_DETECTED]; REMOVE=[REMOVE]; UPGRADINGPRODUCTCODE=[UPGRADINGPRODUCTCODE]&quot;" />
         <CustomAction Id="CustomUnInstallerAction" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
         <InstallExecuteSequence>
-            <Custom Action="CustomPreUpdateAction" After="InstallInitialize"></Custom>
+            <Custom Action="CustomPreUpdateAction" Before="RemoveExistingProducts"></Custom>
             <Custom Action="CustomUnInstallerAction" Before="RemoveFiles"><![CDATA[REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)]]></Custom>
             <Custom Action="CustomInstallerAction" Before="InstallFinalize"></Custom>
         </InstallExecuteSequence>

--- a/packaging/windows/snclient.wxs
+++ b/packaging/windows/snclient.wxs
@@ -15,7 +15,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Name="SNClient" Id="*" UpgradeCode="F4BF03F6-D3DA-44FF-A444-9B64119DA0CE" Language="1033" Codepage="1252" Version="$(var.MajorVersion).$(var.MinorVersion).$(var.RevisionNumber)" Manufacturer="ConSol Consulting and Solutions Software GmbH">
         <Package InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" Compressed="yes" />
-        <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
+        <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed. It must be uninstalled for downgrades." />
         <Property Id="REBOOT" Value="ReallySuppress" />
         <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
@@ -99,7 +99,7 @@
         <SetProperty Id="CustomUnInstallerAction" Sequence="execute" Before="CustomUnInstallerAction" Value="&quot;[INSTALLDIR]snclient.exe&quot; uninstall pkg &quot;INSTALLDIR=[INSTALLDIR]; WIX_UPGRADE_DETECTED=[WIX_UPGRADE_DETECTED]; REMOVE=[REMOVE]; UPGRADINGPRODUCTCODE=[UPGRADINGPRODUCTCODE]&quot;" />
         <CustomAction Id="CustomUnInstallerAction" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="no" />
         <InstallExecuteSequence>
-            <Custom Action="CustomPreUpdateAction" After="InstallInitialize"></Custom>
+            <Custom Action="CustomPreUpdateAction" After="InstallInitialize" Before="RemoveExistingProducts"></Custom>
             <Custom Action="CustomUnInstallerAction" Before="RemoveFiles"><![CDATA[REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)]]></Custom>
             <Custom Action="CustomInstallerAction" Before="InstallFinalize"></Custom>
         </InstallExecuteSequence>


### PR DESCRIPTION
The commit is made entirely using AI, I will only mark it done once I test it.

During upgrades, RemoveExistingProducts (scheduled by MajorUpgrade) ran before CustomPreUpdateAction, which is what stops the snclient Windows service. This meant the old snclient.exe was still held by the running service when MSI tried to delete it. Combined with Restart Manager being disabled (MSIRESTARTMANAGERCONTROL=Disable), MSI could not shut down the process holding the file, causing the installer to show a "Files in Use" dialog or silently fail.

Fixed by:
- Setting MajorUpgrade Schedule="afterInstallInitialize" so old files are removed after InstallInitialize instead of before it
- Adding Before="RemoveExistingProducts" to CustomPreUpdateAction so snclient.exe install pre stops the service before file removal

The corrected sequence during upgrades is now:
  InstallInitialize -> stop service -> remove old files -> install new files -> start service -> InstallFinalize