### PR TITLE
tests: make systemctl service check robust

### DIFF
--- a/t/40_e2e_deb_linux_test.go
+++ b/t/40_e2e_deb_linux_test.go
@@ -69,8 +69,16 @@ func TestDEBinstaller(t *testing.T) {
 
 	runCmd(t, &cmd{
 		Cmd:  "systemctl",
-		Args: []string{"status", "snclient"},
-		Like: []string{`/usr/bin/snclient`, `running`},
+		Args: []string{"is-active", "--quiet", "snclient"},
+	})
+
+	// Check the configured command separately. The process tree in the
+	// human-readable status output may temporarily contain only the process
+	// name while the service is starting.
+	runCmd(t, &cmd{
+		Cmd:  "systemctl",
+		Args: []string{"show", "--property=ExecStart", "--value", "snclient"},
+		Like: []string{`/usr/bin/snclient`},
 	})
 
 	// add custom .ini with correct ownership for snclient user


### PR DESCRIPTION
Should probably fix failing test from https://github.com/ConSol-Monitoring/snclient/pull/419