### PR TITLE
check_tcp and check_ssh: discern between argumentParse errors for help message and other types of errors

### DIFF
--- a/pkg/check_tcp/check_ssh.go
+++ b/pkg/check_tcp/check_ssh.go
@@ -17,11 +17,11 @@ func CheckSSH(_ context.Context, output io.Writer, args []string, sendString str
 		if errors.As(err, &flagsErr) && flagsErr.Type == flags.ErrHelp {
 			fmt.Fprint(output, err.Error())
 
-			return int(3)
+			return 3
 		}
 		fmt.Fprintf(output, "UNKNOWN - %s", err.Error())
 
-		return int(3)
+		return 3
 	}
 
 	if opts.Port == 0 {

--- a/pkg/check_tcp/check_ssh.go
+++ b/pkg/check_tcp/check_ssh.go
@@ -2,17 +2,27 @@ package check_tcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/mackerelio/checkers"
+	"github.com/sni/go-flags"
 )
 
 func CheckSSH(_ context.Context, output io.Writer, args []string, sendString string) int {
 	opts, err := parseArgs(args)
 	if err != nil {
-		fmt.Fprintf(output, "%s", err.Error())
+		var flagsErr *flags.Error
+		if errors.As(err, &flagsErr) && flagsErr.Type == flags.ErrHelp {
+			fmt.Fprint(output, err.Error())
 
-		return 2
+			return int(checkers.UNKNOWN)
+		}
+		fmt.Fprintf(output, "UNKNOWN - %s", err.Error())
+
+		return int(checkers.UNKNOWN)
 	}
 
 	if opts.Port == 0 {

--- a/pkg/check_tcp/check_ssh.go
+++ b/pkg/check_tcp/check_ssh.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/mackerelio/checkers"
 	"github.com/sni/go-flags"
 )
 
@@ -18,11 +17,11 @@ func CheckSSH(_ context.Context, output io.Writer, args []string, sendString str
 		if errors.As(err, &flagsErr) && flagsErr.Type == flags.ErrHelp {
 			fmt.Fprint(output, err.Error())
 
-			return int(checkers.UNKNOWN)
+			return int(3)
 		}
 		fmt.Fprintf(output, "UNKNOWN - %s", err.Error())
 
-		return int(checkers.UNKNOWN)
+		return int(3)
 	}
 
 	if opts.Port == 0 {

--- a/pkg/check_tcp/check_tcp.go
+++ b/pkg/check_tcp/check_tcp.go
@@ -4,6 +4,7 @@ package check_tcp
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -36,8 +37,15 @@ func Check(ctx context.Context, output io.Writer, args []string) int {
 
 	opts, err := parseArgs(args)
 	if err != nil {
-		fmt.Fprintf(output, "%s", err.Error())
-		return 2
+		var flagsErr *flags.Error
+		if errors.As(err, &flagsErr) && flagsErr.Type == flags.ErrHelp {
+			fmt.Fprint(output, err.Error())
+
+			return int(checkers.UNKNOWN)
+		}
+		fmt.Fprintf(output, "UNKNOWN - %s", err.Error())
+
+		return int(checkers.UNKNOWN)
 	}
 
 	ckr := opts.run(output)


### PR DESCRIPTION
both types of errors return 3, but help errors do not prepend "UNKNOWN - " to the front

```
./snclient run check_tcp --foo=bar ; echo $?
UNKNOWN - unknown flag `foo'
3
```

```
./snclient run check_ssh --foo=bar ; echo $?
UNKNOWN - unknown flag `foo'
3
```

```
./snclient run check_tcp --help ; echo $?
Usage:
  check_tcp [OPTIONS]

Application Options:
      --service=              Service name. e.g. ftp, smtp, pop, imap and so on
  -H, --hostname=             Host name or IP Address
  -p, --port=                 Port number
  -s, --send=                 String to send to the server
  -e, --expect-pattern=       Regexp pattern to expect in server response
  -q, --quit=                 String to send server to initiate a clean close of the connection
  -S, --ssl                   Use SSL for the connection.
  -U, --unix-sock=            Unix Domain Socket
      --no-check-certificate  Do not check certificate
  -t, --timeout=              Seconds before connection times out (default: 10)
  -m, --maxbytes=             Close connection once more than this number of bytes are received
  -d, --delay=                Seconds to wait between sending string and polling for response
  -w, --warning=              Response time to result in warning status (seconds)
  -c, --critical=             Response time to result in critical status (seconds) (default: 10)
  -E, --escape                Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By default, nothing added to send, \r\n added to
                              end of quit
  -W, --error-warning         Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation
                              result of -c option eval takes priority.
  -C, --expect-closed         Verify that the port/unixsock is closed. If the port/unixsock is closed, OK; if open, follow the ErrWarning flag. This option only
                              verifies the connection.
  -v, --verbose               Enables verbose logging of the actions taken.

Help Options:
  -h, --help                  Show this help message
3
```

```
./snclient run check_ssh --help ; echo $?
Usage:
  check_tcp [OPTIONS]

Application Options:
      --service=              Service name. e.g. ftp, smtp, pop, imap and so on
  -H, --hostname=             Host name or IP Address
  -p, --port=                 Port number
  -s, --send=                 String to send to the server
  -e, --expect-pattern=       Regexp pattern to expect in server response
  -q, --quit=                 String to send server to initiate a clean close of the connection
  -S, --ssl                   Use SSL for the connection.
  -U, --unix-sock=            Unix Domain Socket
      --no-check-certificate  Do not check certificate
  -t, --timeout=              Seconds before connection times out (default: 10)
  -m, --maxbytes=             Close connection once more than this number of bytes are received
  -d, --delay=                Seconds to wait between sending string and polling for response
  -w, --warning=              Response time to result in warning status (seconds)
  -c, --critical=             Response time to result in critical status (seconds) (default: 10)
  -E, --escape                Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By default, nothing added to send, \r\n added to
                              end of quit
  -W, --error-warning         Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation
                              result of -c option eval takes priority.
  -C, --expect-closed         Verify that the port/unixsock is closed. If the port/unixsock is closed, OK; if open, follow the ErrWarning flag. This option only
                              verifies the connection.
  -v, --verbose               Enables verbose logging of the actions taken.

Help Options:
  -h, --help                  Show this help message
3
```

check_ssh help text is not specialized for check_ssh , since its aliasing check_tcp , but that is unrelated