### PR TITLE
ExporterExporter improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=

--- a/packaging/snclient.ini
+++ b/packaging/snclient.ini
@@ -136,6 +136,9 @@ modules dir = ${shared-path}/exporter_modules
 ; default module - set default module if no specific module is requested
 default module =
 
+; allowed methods - Comma seperated list of allowed exporter_exporter methods from: http, exec, and file. If set, only modules with these methods are loaded.
+allowed methods =
+
 ; use default web attributes here, ex.: password, allowed hosts, certificates, etc...
 
 

--- a/packaging/snclient.ini
+++ b/packaging/snclient.ini
@@ -133,6 +133,9 @@ url prefix = /
 ; modules dir - set folder with yaml module definitions
 modules dir = ${shared-path}/exporter_modules
 
+; modules dir watcher - enable watcher to reload modules on file changes including writes, creations, deletions and renames
+modules dir watcher = disabled
+
 ; default module - set default module if no specific module is requested
 default module =
 

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -52,9 +53,9 @@ type HandlerExporterExporter struct {
 	requirePassword  bool
 	defaultModule    string
 	snc              *Agent
-	conf             *ConfigSection
-	runSet           *AgentRunSet
+	moduleDir        string
 	modules          map[string]*exporterModuleConfig
+	modulesLock      sync.RWMutex
 	allowedHosts     *AllowedHostConfig
 	moduleDirWatcher *fsnotify.Watcher
 }
@@ -95,38 +96,25 @@ func (l *HandlerExporterExporter) Stop() {
 	l.listener.Stop()
 }
 
-// This function is intended to be called to reinitialize after changes in the config directory
-func (l *HandlerExporterExporter) stopAndReinitialize() {
-	restartPeriod := time.Second * 5
+func (l *HandlerExporterExporter) reloadModules() {
+	log.Tracef("exporter_exporter reloading modules from %s", l.moduleDir)
 
-	log.Tracef("exporter_exporter stopping and reinitializing")
+	newModules, err := l.readModules(l.snc, l.moduleDir)
+	if err != nil {
+		log.Tracef("exporter_exporter reload failed: %s", err.Error())
 
-	stopAndReinitializeFunc := func() {
-		l.Stop()
-		l.listener = nil
-
-		time.Sleep(restartPeriod)
-
-		err := l.Init(l.snc, l.conf, nil, l.runSet)
-		if err != nil {
-			log.Tracef("exporter_exporter reinitialize failed: %s", err.Error())
-		}
-
-		// time.Sleep(restartPeriod)
-
-		err = l.Start()
-		if err != nil {
-			log.Tracef("exporter_exporter start failed: %s", err.Error())
-		}
+		return
 	}
 
-	go stopAndReinitializeFunc()
+	l.modulesLock.Lock()
+	l.modules = newModules
+	l.modulesLock.Unlock()
+
+	log.Tracef("exporter_exporter reload complete, %d modules loaded", len(newModules))
 }
 
 func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Config, runSet *AgentRunSet) error {
 	l.snc = snc
-	l.conf = conf
-	l.runSet = runSet
 
 	err := setListenerAuthInit(&l.password, &l.requirePassword, conf)
 	if err != nil {
@@ -144,14 +132,18 @@ func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Confi
 	defaultModule, _ := conf.GetString("default module")
 	l.defaultModule = defaultModule
 
-	l.modules = map[string]*exporterModuleConfig{}
 	moduleDir, _ := conf.GetString("modules dir")
+	l.moduleDir = moduleDir
+
+	l.modules = map[string]*exporterModuleConfig{}
 	if moduleDir != "" {
 		modules, err2 := l.readModules(snc, moduleDir)
 		if err2 != nil {
 			return err2
 		}
 		l.modules = modules
+
+		l.WatchModulesConfigDirectory(moduleDir)
 	}
 
 	allowedHosts, err2 := NewAllowedHostConfig(conf)
@@ -219,12 +211,13 @@ func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map
 	log.Tracef("In the ExporterExporter config directory: '%s' , %d config files were added without errors, %d config files had errors",
 		moduleDir, mfsWithoutErrorsCount, mfsWithErrorsCount)
 
-	l.WatchConfigDirectory(moduleDir)
-
 	return modules, nil
 }
 
 func (l *HandlerExporterExporter) JSON() []map[string]string {
+	l.modulesLock.RLock()
+	defer l.modulesLock.RUnlock()
+
 	list := make([]map[string]string, 0, len(l.modules))
 	ssl := "0"
 	if l.listener.tlsConfig != nil {
@@ -299,6 +292,9 @@ func (l *HandlerWebExporterExporter) ServeHTTP(res http.ResponseWriter, req *htt
 }
 
 func (l *HandlerExporterExporter) listModules(res http.ResponseWriter, req *http.Request) {
+	l.modulesLock.RLock()
+	defer l.modulesLock.RUnlock()
+
 	switch req.Header.Get("Accept") {
 	case "application/json":
 		log.Debugf("Listing modules in json")
@@ -340,7 +336,9 @@ func (l *HandlerExporterExporter) doProxy(res http.ResponseWriter, req *http.Req
 
 	log.Debugf("running module %v\n", mod[0])
 
+	l.modulesLock.RLock()
 	mcfg, ok := l.modules[mod[0]]
+	l.modulesLock.RUnlock()
 	if !ok {
 		log.Warnf("unknown module requested  %v\n", mod)
 		http.Error(res, fmt.Sprintf("unknown module %v\n", mod), http.StatusNotFound)
@@ -662,7 +660,7 @@ func (m exporterExecConfig) ServeHTTP(res http.ResponseWriter, req *http.Request
 	LogError2(res.Write([]byte("\n")))
 }
 
-func (l *HandlerExporterExporter) WatchConfigDirectory(moduleDir string) {
+func (l *HandlerExporterExporter) WatchModulesConfigDirectory(moduleDir string) {
 	watcher, err := fsnotify.NewWatcher()
 
 	if err != nil {
@@ -687,12 +685,12 @@ func (l *HandlerExporterExporter) WatchConfigDirectory(moduleDir string) {
 	}
 
 	log.Debugf("Starting file watcher on path: %s", absDir)
-	go l.WatcherFunc(watcher)
+	go l.ModulesConfigDirectoryWatcherFunc(watcher)
 }
 
-func (l *HandlerExporterExporter) WatcherFunc(watcher *fsnotify.Watcher) {
+func (l *HandlerExporterExporter) ModulesConfigDirectoryWatcherFunc(watcher *fsnotify.Watcher) {
 	debounceDuration := time.Second * 5
-	lastSignificantEvent := time.Now() // starting counts as an event
+	lastSignificantEvent := time.Now()
 
 	for {
 		select {
@@ -703,15 +701,14 @@ func (l *HandlerExporterExporter) WatcherFunc(watcher *fsnotify.Watcher) {
 
 			if event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) ||
 				event.Has(fsnotify.Rename) || event.Has(fsnotify.Write) {
-
 				now := time.Now()
 				if now.Sub(lastSignificantEvent) <= debounceDuration {
-					return
+					continue
 				}
 				lastSignificantEvent = now
 
 				log.Tracef("file watcher event, reinitializing due to operation: %s , %s", event.Op.String(), event.Name)
-				l.stopAndReinitialize()
+				l.reloadModules()
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -732,6 +732,12 @@ func (l *HandlerExporterExporter) ModulesConfigDirectoryWatcherFunc(watcher *fsn
 				if now.Sub(lastSignificantEvent) <= debounceDuration {
 					continue
 				}
+
+				ext := filepath.Ext(event.Name)
+				if ext != ".yml" && ext != ".yaml" {
+					continue
+				}
+
 				lastSignificantEvent = now
 
 				log.Tracef("file watcher event, reinitializing due to operation: %s , %s", event.Op.String(), event.Name)

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -140,6 +140,8 @@ func (l *HandlerExporterExporter) GetMappings(*Agent) []URLMapping {
 	}
 }
 
+// adds ExporterExporter module config files found in the module directory
+// does not return errors if config files could not be correctly added
 func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map[string]*exporterModuleConfig, error) {
 	modules := map[string]*exporterModuleConfig{}
 
@@ -157,6 +159,8 @@ func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map
 		".yml":  true,
 		".yaml": true,
 	}
+	mfsWithoutErrorsCount := 0
+	mfsWithErrorsCount := 0
 	for _, entry := range mfs {
 		fullpath := filepath.Join(moduleDir, entry.Name())
 		if entry.IsDir() || !yamlSuffixes[filepath.Ext(entry.Name())] {
@@ -166,9 +170,16 @@ func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map
 		}
 
 		if err := modulesAdd(snc, modules, entry, fullpath); err != nil {
-			return nil, err
+			mfsWithErrorsCount++
+
+			continue
 		}
+
+		mfsWithoutErrorsCount++
 	}
+
+	log.Tracef("In the ExporterExporter config directory: '%s' , %d config files were added without errors, %d config files had errors",
+		moduleDir, mfsWithoutErrorsCount, mfsWithErrorsCount)
 
 	return modules, nil
 }
@@ -193,6 +204,7 @@ func (l *HandlerExporterExporter) JSON() []map[string]string {
 	return list
 }
 
+// tries adding a module from a given a filesystem entry and path
 func modulesAdd(snc *Agent, modules map[string]*exporterModuleConfig, entry fs.DirEntry, fullpath string) error {
 	moduleName := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
 	if _, ok := modules[moduleName]; ok {
@@ -206,6 +218,8 @@ func modulesAdd(snc *Agent, modules map[string]*exporterModuleConfig, entry fs.D
 
 	mcfg, err := readModuleConfig(moduleName, file)
 	if err != nil {
+		log.Errorf("failed reading configs %s, %s", fullpath, err.Error())
+
 		return fmt.Errorf("failed reading configs %s, %w", fullpath, err)
 	}
 	mcfg.snc = snc
@@ -343,6 +357,7 @@ type exporterFileConfig struct {
 	mcfg *exporterModuleConfig
 }
 
+// reads, parses and verifies an individual ExporterExporter config file
 func readModuleConfig(name string, r io.Reader) (*exporterModuleConfig, error) {
 	buf := bytes.Buffer{}
 	if _, err := io.Copy(&buf, r); err != nil {

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -45,20 +45,21 @@ func init() {
 }
 
 type HandlerExporterExporter struct {
-	noCopy           noCopy
-	handler          http.Handler
-	listener         *Listener
-	urlPrefix        string
-	password         string
-	requirePassword  bool
-	defaultModule    string
-	snc              *Agent
-	moduleDir        string
-	allowedMethods   []string
-	modules          map[string]*exporterModuleConfig
-	modulesLock      sync.RWMutex
-	allowedHosts     *AllowedHostConfig
-	moduleDirWatcher *fsnotify.Watcher
+	noCopy                  noCopy
+	handler                 http.Handler
+	listener                *Listener
+	urlPrefix               string
+	password                string
+	requirePassword         bool
+	defaultModule           string
+	snc                     *Agent
+	moduleDir               string
+	moduleDirWatcherEnabled bool
+	allowedMethods          []string
+	modules                 map[string]*exporterModuleConfig
+	modulesLock             sync.RWMutex
+	allowedHosts            *AllowedHostConfig
+	moduleDirWatcher        *fsnotify.Watcher
 }
 
 // ensure we fully implement the RequestHandlerHTTP type
@@ -136,6 +137,12 @@ func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Confi
 	moduleDir, _ := conf.GetString("modules dir")
 	l.moduleDir = moduleDir
 
+	moduleDirWatcherEnabled, enableModuleDirWatcherPresent, err := conf.GetBool("modules dir watcher")
+	l.moduleDirWatcherEnabled = false
+	if enableModuleDirWatcherPresent && err == nil {
+		l.moduleDirWatcherEnabled = moduleDirWatcherEnabled
+	}
+
 	allowedMethods, allowedMethodsPresent := conf.GetString("allowed methods")
 	if !allowedMethodsPresent || allowedMethods == "" {
 		l.allowedMethods = []string{}
@@ -151,7 +158,9 @@ func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Confi
 		}
 		l.modules = modules
 
-		l.WatchModulesConfigDirectory(moduleDir)
+		if l.moduleDirWatcherEnabled {
+			l.WatchModulesConfigDirectory(moduleDir)
+		}
 	}
 
 	allowedHosts, err2 := NewAllowedHostConfig(conf)

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -226,7 +226,14 @@ type HandlerWebExporterExporter struct {
 }
 
 func (l *HandlerWebExporterExporter) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	switch req.URL.Path {
+	if !strings.HasPrefix(req.URL.Path, l.Handler.urlPrefix) {
+		res.WriteHeader(http.StatusBadRequest)
+		LogError2(res.Write([]byte("400 - missing url prefix\n")))
+
+		return
+	}
+	path := strings.TrimPrefix(req.URL.Path, l.Handler.urlPrefix)
+	switch path {
 	case "/list":
 		l.Handler.listModules(res, req)
 	case "/proxy":

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	"github.com/goccy/go-json"
 	"gopkg.in/yaml.v3"
 )
@@ -42,16 +44,19 @@ func init() {
 }
 
 type HandlerExporterExporter struct {
-	noCopy          noCopy
-	handler         http.Handler
-	listener        *Listener
-	urlPrefix       string
-	password        string
-	requirePassword bool
-	defaultModule   string
-	snc             *Agent
-	modules         map[string]*exporterModuleConfig
-	allowedHosts    *AllowedHostConfig
+	noCopy           noCopy
+	handler          http.Handler
+	listener         *Listener
+	urlPrefix        string
+	password         string
+	requirePassword  bool
+	defaultModule    string
+	snc              *Agent
+	conf             *ConfigSection
+	runSet           *AgentRunSet
+	modules          map[string]*exporterModuleConfig
+	allowedHosts     *AllowedHostConfig
+	moduleDirWatcher *fsnotify.Watcher
 }
 
 // ensure we fully implement the RequestHandlerHTTP type
@@ -84,11 +89,44 @@ func (l *HandlerExporterExporter) Start() error {
 }
 
 func (l *HandlerExporterExporter) Stop() {
+	if l.moduleDirWatcher != nil {
+		LogError2(nil, l.moduleDirWatcher.Close())
+	}
 	l.listener.Stop()
+}
+
+// This function is intended to be called to reinitialize after changes in the config directory
+func (l *HandlerExporterExporter) stopAndReinitialize() {
+	restartPeriod := time.Second * 5
+
+	log.Tracef("exporter_exporter stopping and reinitializing")
+
+	stopAndReinitializeFunc := func() {
+		l.Stop()
+		l.listener = nil
+
+		time.Sleep(restartPeriod)
+
+		err := l.Init(l.snc, l.conf, nil, l.runSet)
+		if err != nil {
+			log.Tracef("exporter_exporter reinitialize failed: %s", err.Error())
+		}
+
+		// time.Sleep(restartPeriod)
+
+		err = l.Start()
+		if err != nil {
+			log.Tracef("exporter_exporter start failed: %s", err.Error())
+		}
+	}
+
+	go stopAndReinitializeFunc()
 }
 
 func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Config, runSet *AgentRunSet) error {
 	l.snc = snc
+	l.conf = conf
+	l.runSet = runSet
 
 	err := setListenerAuthInit(&l.password, &l.requirePassword, conf)
 	if err != nil {
@@ -180,6 +218,8 @@ func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map
 
 	log.Tracef("In the ExporterExporter config directory: '%s' , %d config files were added without errors, %d config files had errors",
 		moduleDir, mfsWithoutErrorsCount, mfsWithErrorsCount)
+
+	l.WatchConfigDirectory(moduleDir)
 
 	return modules, nil
 }
@@ -620,4 +660,64 @@ func (m exporterExecConfig) ServeHTTP(res http.ResponseWriter, req *http.Request
 	res.WriteHeader(http.StatusOK)
 	LogError2(res.Write([]byte(stdout)))
 	LogError2(res.Write([]byte("\n")))
+}
+
+func (l *HandlerExporterExporter) WatchConfigDirectory(moduleDir string) {
+	watcher, err := fsnotify.NewWatcher()
+
+	if err != nil {
+		log.Errorf("error creating file watcher: %s", err)
+
+		return
+	}
+	l.moduleDirWatcher = watcher
+
+	absDir, err := filepath.Abs(moduleDir)
+	if err != nil {
+		log.Errorf("error resolving absolute path for file watcher: %s", err)
+
+		return
+	}
+
+	err = watcher.Add(absDir)
+	if err != nil {
+		log.Errorf("error adding path to the file watcher: %s", err)
+
+		return
+	}
+
+	log.Debugf("Starting file watcher on path: %s", absDir)
+	go l.WatcherFunc(watcher)
+}
+
+func (l *HandlerExporterExporter) WatcherFunc(watcher *fsnotify.Watcher) {
+	debounceDuration := time.Second * 5
+	lastSignificantEvent := time.Now() // starting counts as an event
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) ||
+				event.Has(fsnotify.Rename) || event.Has(fsnotify.Write) {
+
+				now := time.Now()
+				if now.Sub(lastSignificantEvent) <= debounceDuration {
+					return
+				}
+				lastSignificantEvent = now
+
+				log.Tracef("file watcher event, reinitializing due to operation: %s , %s", event.Op.String(), event.Name)
+				l.stopAndReinitialize()
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Tracef("file watcher error: %s", err.Error())
+		}
+	}
 }

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-
 	"github.com/goccy/go-json"
 	"gopkg.in/yaml.v3"
 )
@@ -307,7 +306,16 @@ func (l *HandlerExporterExporter) listModules(res http.ResponseWriter, req *http
 	switch req.Header.Get("Accept") {
 	case "application/json":
 		log.Debugf("Listing modules in json")
-		moduleJSON, err := json.Marshal(l.modules)
+		modulesWithPrefix := make(map[string]*exporterModuleConfig, len(l.modules))
+		for name, mcfg := range l.modules {
+			if mcfg.HTTP.Path == "" {
+				continue
+			}
+
+			mcfg.HTTP.Path = l.urlPrefix + "/proxy?module=" + name
+			modulesWithPrefix[name] = mcfg
+		}
+		moduleJSON, err := json.Marshal(modulesWithPrefix)
 		if err != nil {
 			log.Error(err)
 			http.Error(res, "Failed to produce JSON", http.StatusInternalServerError)
@@ -324,7 +332,7 @@ func (l *HandlerExporterExporter) listModules(res http.ResponseWriter, req *http
 		LogError2(res.Write([]byte("<h2>Exporters:</h2>\n")))
 		LogError2(res.Write([]byte("<ul>\n")))
 		for name := range l.modules {
-			LogError2(fmt.Fprintf(res, "<li><a href=\"/proxy?module=%s\">%s</a></li>\n", name, name))
+			LogError2(fmt.Fprintf(res, "<li><a href=\"%s/proxy?module=%s\">%s</a></li>\n", l.urlPrefix, name, name))
 		}
 		LogError2(res.Write([]byte("</ul>\n")))
 	}
@@ -676,7 +684,6 @@ func (m exporterExecConfig) ServeHTTP(res http.ResponseWriter, req *http.Request
 
 func (l *HandlerExporterExporter) WatchModulesConfigDirectory(moduleDir string) {
 	watcher, err := fsnotify.NewWatcher()
-
 	if err != nil {
 		log.Errorf("error creating file watcher: %s", err)
 

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -308,12 +308,9 @@ func (l *HandlerExporterExporter) listModules(res http.ResponseWriter, req *http
 		log.Debugf("Listing modules in json")
 		modulesWithPrefix := make(map[string]*exporterModuleConfig, len(l.modules))
 		for name, mcfg := range l.modules {
-			if mcfg.HTTP.Path == "" {
-				continue
-			}
-
-			mcfg.HTTP.Path = l.urlPrefix + "/proxy?module=" + name
-			modulesWithPrefix[name] = mcfg
+			cp := *mcfg
+			cp.HTTP.Path = l.urlPrefix + "/proxy?module=" + name
+			modulesWithPrefix[name] = &cp
 		}
 		moduleJSON, err := json.Marshal(modulesWithPrefix)
 		if err != nil {
@@ -322,13 +319,13 @@ func (l *HandlerExporterExporter) listModules(res http.ResponseWriter, req *http
 
 			return
 		}
-		res.WriteHeader(http.StatusOK)
 		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusOK)
 		LogError2(res.Write(moduleJSON))
 	default:
 		log.Debugf("Listing modules in html")
-		res.WriteHeader(http.StatusOK)
 		res.Header().Set("Content-Type", "text/html; charset=utf-8")
+		res.WriteHeader(http.StatusOK)
 		LogError2(res.Write([]byte("<h2>Exporters:</h2>\n")))
 		LogError2(res.Write([]byte("<ul>\n")))
 		for name := range l.modules {

--- a/pkg/snclient/listen_exporterexporter.go
+++ b/pkg/snclient/listen_exporterexporter.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -54,6 +55,7 @@ type HandlerExporterExporter struct {
 	defaultModule    string
 	snc              *Agent
 	moduleDir        string
+	allowedMethods   []string
 	modules          map[string]*exporterModuleConfig
 	modulesLock      sync.RWMutex
 	allowedHosts     *AllowedHostConfig
@@ -135,6 +137,13 @@ func (l *HandlerExporterExporter) Init(snc *Agent, conf *ConfigSection, _ *Confi
 	moduleDir, _ := conf.GetString("modules dir")
 	l.moduleDir = moduleDir
 
+	allowedMethods, allowedMethodsPresent := conf.GetString("allowed methods")
+	if !allowedMethodsPresent || allowedMethods == "" {
+		l.allowedMethods = []string{}
+	} else {
+		l.allowedMethods = strings.Split(allowedMethods, ",")
+	}
+
 	l.modules = map[string]*exporterModuleConfig{}
 	if moduleDir != "" {
 		modules, err2 := l.readModules(snc, moduleDir)
@@ -199,7 +208,7 @@ func (l *HandlerExporterExporter) readModules(snc *Agent, moduleDir string) (map
 			continue
 		}
 
-		if err := modulesAdd(snc, modules, entry, fullpath); err != nil {
+		if err := l.modulesAdd(snc, modules, entry, fullpath); err != nil {
 			mfsWithErrorsCount++
 
 			continue
@@ -238,7 +247,7 @@ func (l *HandlerExporterExporter) JSON() []map[string]string {
 }
 
 // tries adding a module from a given a filesystem entry and path
-func modulesAdd(snc *Agent, modules map[string]*exporterModuleConfig, entry fs.DirEntry, fullpath string) error {
+func (l *HandlerExporterExporter) modulesAdd(snc *Agent, modules map[string]*exporterModuleConfig, entry fs.DirEntry, fullpath string) error {
 	moduleName := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
 	if _, ok := modules[moduleName]; ok {
 		return fmt.Errorf("module %s is already defined", moduleName)
@@ -249,7 +258,7 @@ func modulesAdd(snc *Agent, modules map[string]*exporterModuleConfig, entry fs.D
 	}
 	defer file.Close()
 
-	mcfg, err := readModuleConfig(moduleName, file)
+	mcfg, err := l.readModuleConfig(moduleName, file)
 	if err != nil {
 		log.Errorf("failed reading configs %s, %s", fullpath, err.Error())
 
@@ -396,7 +405,7 @@ type exporterFileConfig struct {
 }
 
 // reads, parses and verifies an individual ExporterExporter config file
-func readModuleConfig(name string, r io.Reader) (*exporterModuleConfig, error) {
+func (l *HandlerExporterExporter) readModuleConfig(name string, r io.Reader) (*exporterModuleConfig, error) {
 	buf := bytes.Buffer{}
 	if _, err := io.Copy(&buf, r); err != nil {
 		return nil, fmt.Errorf("io.Copy: %s", err.Error())
@@ -407,16 +416,21 @@ func readModuleConfig(name string, r io.Reader) (*exporterModuleConfig, error) {
 		return nil, fmt.Errorf("yaml.Unmarshal: %s", err.Error())
 	}
 
-	if err := checkModuleConfig(name, &cfg); err != nil {
+	if err := l.checkModuleConfig(name, &cfg); err != nil {
 		return nil, err
 	}
 
 	return &cfg, nil
 }
 
-func checkModuleConfig(name string, cfg *exporterModuleConfig) error {
+// verifies a module config to see if it is correct.
+func (l *HandlerExporterExporter) checkModuleConfig(name string, cfg *exporterModuleConfig) error {
 	if len(cfg.XXX) != 0 {
 		return fmt.Errorf("unknown module configuration fields: %v", cfg.XXX)
+	}
+
+	if len(l.allowedMethods) > 0 && !slices.Contains(l.allowedMethods, cfg.Method) {
+		return fmt.Errorf("allowed methods: '%s' does not contain the module config method: '%s'", strings.Join(l.allowedMethods, ","), cfg.Method)
 	}
 
 	cfg.name = name

--- a/pkg/snclient/listen_exporterexporter_test.go
+++ b/pkg/snclient/listen_exporterexporter_test.go
@@ -1,0 +1,438 @@
+package snclient
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExporterExporterSkipsUnparsableFiles(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	goodYAML := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "some_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "good_module.yaml"),
+		[]byte(goodYAML), 0o600,
+	))
+
+	badYAMLSyntax := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "bad_metrics.prom") + `
+  indentation_error_here
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "bad_syntax.yaml"),
+		[]byte(badYAMLSyntax), 0o600,
+	))
+
+	duplicateYAML := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "dup_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "good_module.yml"),
+		[]byte(duplicateYAML), 0o600,
+	))
+
+	unknownFieldYAML := `
+method: file
+unknown_field: true
+file:
+  path: ` + filepath.Join(modulesDir, "unknown_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "bad_unknown.yaml"),
+		[]byte(unknownFieldYAML), 0o600,
+	))
+
+	noMethodYAML := `
+file:
+  path: ` + filepath.Join(modulesDir, "nomethod_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "bad_nomethod.yaml"),
+		[]byte(noMethodYAML), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45670
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45670/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "good_module", "only the valid module should be listed")
+	assert.NotContainsf(t, string(body), "bad_syntax", "bad syntax module should be skipped")
+	assert.NotContainsf(t, string(body), "bad_unknown", "unknown field module should be skipped")
+	assert.NotContainsf(t, string(body), "bad_nomethod", "unknown method module should be skipped")
+	assert.NotContainsf(t, string(body), "good_module.yml", "duplicate named module should be skipped")
+}
+
+func TestExporterExporterAllowedMethods(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	fileModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "allowed_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "file_module.yaml"),
+		[]byte(fileModule), 0o600,
+	))
+
+	httpModule := `
+method: http
+http:
+  port: 9090
+  path: /metrics
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "http_module.yaml"),
+		[]byte(httpModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45671
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+require password = false
+allowed methods = file
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45671/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "file_module", "file method module should be listed")
+	assert.NotContainsf(t, string(body), "http_module", "http method module should be excluded by allowed methods")
+}
+
+func TestExporterExporterAllowedMethodsMulti(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	fileModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "file_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "file_module.yaml"),
+		[]byte(fileModule), 0o600,
+	))
+
+	httpModule := `
+method: http
+http:
+  port: 9090
+  path: /metrics
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "http_module.yaml"),
+		[]byte(httpModule), 0o600,
+	))
+
+	execModule := `
+method: exec
+exec:
+  command: /usr/bin/prometheus-foo
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "exec_module.yaml"),
+		[]byte(execModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45676
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+require password = false
+allowed methods = file,http
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45676/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "file_module", "file method module should be listed")
+	assert.Containsf(t, string(body), "http_module", "http method module should be listed")
+	assert.NotContainsf(t, string(body), "exec_module", "exec method module should be excluded by allowed methods")
+}
+
+func TestExporterExporterAllFilesFailing(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	badYAML := `
+method: file
+unknown: invalid
+  indentation: broken
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "bad1.yaml"),
+		[]byte(badYAML), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "bad2.yaml"),
+		[]byte(badYAML), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45672
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45672/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "<h2>Exporters:</h2>", "agent should start even with all config files failing")
+	assert.NotContainsf(t, string(body), "bad1", "no module should be listed when all files fail")
+	assert.NotContainsf(t, string(body), "bad2", "no module should be listed when all files fail")
+}
+
+func TestExporterExporterListEndpointWithPrefix(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	fileModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "prefixed_metrics.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "prefixed_module.yaml"),
+		[]byte(fileModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45673
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /hello
+modules dir = ` + modulesDir + `
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45673/hello/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "/hello/proxy?module=prefixed_module", "HTML href should contain the url prefix")
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"http://127.0.0.1:45673/hello/list", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/json")
+	jsonRes, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	jsonBody, err := io.ReadAll(jsonRes.Body)
+	require.NoError(t, err)
+	jsonRes.Body.Close()
+
+	assert.Containsf(t, string(jsonBody), "/hello/proxy?module=prefixed_module",
+		"JSON output should contain the prefixed proxy URL")
+	assert.Containsf(t, string(jsonBody), "prefixed_module",
+		"JSON output should contain the module name")
+}
+
+func TestExporterExporterConfigDirectoryReload(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	initialModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "initial.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "initial.yaml"),
+		[]byte(initialModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45674
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45674/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "initial", "initial module should be listed")
+
+	time.Sleep(7 * time.Second)
+
+	newModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "reloaded.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "reloaded.yaml"),
+		[]byte(newModule), 0o600,
+	))
+
+	time.Sleep(3 * time.Second)
+
+	res = waitForStatusOK(t, "http://127.0.0.1:45674/list")
+	body, err = io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "reloaded", "newly added module should be listed after reload")
+	assert.Containsf(t, string(body), "initial", "original module should still be listed after reload")
+}
+
+func TestExporterExporterDefaults(t *testing.T) {
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45675
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45675/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Containsf(t, string(body), "<h2>Exporters:</h2>", "list endpoint should work with default prefix")
+}
+
+func waitForStatusOK(t *testing.T, url string) *http.Response {
+	t.Helper()
+
+	var lastErr error
+	for range 300 {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+		require.NoErrorf(t, err, "request created")
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+
+			continue
+		}
+
+		if res.StatusCode == http.StatusOK {
+			return res
+		}
+		res.Body.Close()
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s: %v", url, lastErr)
+
+	return nil
+}

--- a/pkg/snclient/listen_exporterexporter_test.go
+++ b/pkg/snclient/listen_exporterexporter_test.go
@@ -348,6 +348,7 @@ port = ${/settings/WEB/server/port}
 use ssl = ${/settings/WEB/server/use ssl}
 url prefix = /
 modules dir = ` + modulesDir + `
+modules dir watcher = true
 require password = false
 `
 	snc := StartTestAgent(t, config)
@@ -406,6 +407,66 @@ require password = false
 	res.Body.Close()
 
 	assert.Containsf(t, string(body), "<h2>Exporters:</h2>", "list endpoint should work with default prefix")
+}
+
+func TestExporterExporterConfigDirectoryNoReloadWhenWatcherDisabled(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	initialModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "static.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "static.yaml"),
+		[]byte(initialModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45677
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+modules dir watcher = false
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45677/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "static", "initial module should be listed")
+
+	newModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "not_picked_up.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "not_picked_up.yaml"),
+		[]byte(newModule), 0o600,
+	))
+
+	time.Sleep(7 * time.Second)
+
+	res = waitForStatusOK(t, "http://127.0.0.1:45677/list")
+	body, err = io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "static", "original module should still be listed")
+	assert.NotContainsf(t, string(body), "not_picked_up", "new module should NOT be listed when watcher is disabled")
 }
 
 func waitForStatusOK(t *testing.T, url string) *http.Response {

--- a/pkg/snclient/listen_exporterexporter_test.go
+++ b/pkg/snclient/listen_exporterexporter_test.go
@@ -469,6 +469,79 @@ file:
 	assert.NotContainsf(t, string(body), "not_picked_up", "new module should NOT be listed when watcher is disabled")
 }
 
+func TestExporterExporterFileWatcherIgnoresNonYaml(t *testing.T) {
+	modulesDir := t.TempDir()
+
+	initialModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "first.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "first.yaml"),
+		[]byte(initialModule), 0o600,
+	))
+
+	config := `
+[/modules]
+WEBServer = enabled
+ExporterExporterServer = enabled
+
+[/settings/WEB/server]
+port = 45678
+use ssl = false
+require password = false
+
+[/settings/ExporterExporter/server]
+port = ${/settings/WEB/server/port}
+use ssl = ${/settings/WEB/server/use ssl}
+url prefix = /
+modules dir = ` + modulesDir + `
+modules dir watcher = true
+require password = false
+`
+	snc := StartTestAgent(t, config)
+	defer StopTestAgent(t, snc)
+
+	res := waitForStatusOK(t, "http://127.0.0.1:45678/list")
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "first", "initial yaml module should be listed")
+
+	time.Sleep(6 * time.Second)
+
+	yamlModule := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "picked_up.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "picked_up.yml"),
+		[]byte(yamlModule), 0o600,
+	))
+
+	txtFile := `
+method: file
+file:
+  path: ` + filepath.Join(modulesDir, "ignored.prom") + `
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(modulesDir, "ignored.txt"),
+		[]byte(txtFile), 0o600,
+	))
+
+	time.Sleep(3 * time.Second)
+
+	res = waitForStatusOK(t, "http://127.0.0.1:45678/list")
+	body, err = io.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Containsf(t, string(body), "first", "original module should still be listed")
+	assert.Containsf(t, string(body), "picked_up", "yml file should be picked up by watcher")
+	assert.NotContainsf(t, string(body), "ignored", "non-yml/yaML file should be ignored by watcher")
+}
+
 func waitForStatusOK(t *testing.T, url string) *http.Response {
 	t.Helper()
 


### PR DESCRIPTION
Fix 'url prefix' not working. ExporterExporter was registering the prefixes correctly so that listener routed them to the ExporterExporter. But it was not removing the prefix in ServeHTTP before checking if the remaining portion is "/list" or "/proxy"

---

Read modules: The ExporterExporter can specify a module configuration path, in which multiple module config files can be put inside. If opening/parsing/validating one of the configs failed, it would return an error that would propage upwards to the snclient module initialization system. This would make snclient module agent exit, due to ExporterExporter module not being able to start. 

In this PR, it just skips over the modules that cause errors, this can be either due to bad YAML syntax, file being unparsable as a module config file, file not being readable etc.

Even if all of the module config files are wrong, it does not return an error and cause snclient to stop.

---

File watcher: The module directory is now watched for changes using fsnotify. This uses a new library: [fsnotify](https://github.com/fsnotify/fsnotify) , which uses inodes on Linux and 'ReadDirectoryChangesW' on windows. Seems to be more robust than manually checking files.

If a file is written into, deleted or renamed an event is fired. The events that are related to non .yml / .yaml files are ignored. If so, the modules are regenerated from the module config folder. Until the regeneration is complete, the exporter_exporter uses the old parsed config, but once the new one is ready it is switched to new version. The change is protected with a mutex. After a change new events that come for 5 seconds are ignored in a debounce period.

I checked this both by hand in Linux and Windows, seems to be notificing and firing events, and reloading the modules index without problems.

```
curl http://127.0.0.1:[port]/[url prefix]/list -u :[password]

# prefix is set to 'hello' , password is set to 'nicepassword'
curl 127.0.0.1:8443/hello/list -u :nicepassword
<h2>Exporters:</h2>
<ul>
<li><a href="/hello/proxy?module=node-zart">node-zart</a></li>
<li><a href="/hello/proxy?module=node">node</a></li>
</ul>
```

the file watcher is toggleable using the 'modules dir watcher' option. By default it is false, so only users needing this may turn it on knowing its possible side effects.

---

Add 'allowed methods' configuration point.

Exporter_exporter has multiple ways of getting results from a prometheus conforming exporter. Https does a query and gets the output, file reads from a file (which is presumably refreshed from time to time) and exec calls an exporter directly.

Add a whitelist in the exporter_exporter configuration section called 'allowed methods', if its populated it will reject module definitions that dont use its methods. Is meant to protect against 'exec' types of modules.

---
