### PR TITLE
check_drivesize windows: rework "mounted" attribute in the volume discovery path

### DIFF
--- a/pkg/snclient/check_drivesize_windows.go
+++ b/pkg/snclient/check_drivesize_windows.go
@@ -28,6 +28,10 @@ const (
 	IoctlStorageGetMediaTypesEX = (IoctlStorageBase << 16) | (FileAnyAccess << 14) | (StorageGetMediaTypesEX << 2) | MethodBuffered
 	MaxMediaTypes               = 128
 
+	FileReadAccess             = 0x0001
+	StorageCheckVerify         = 0x0200
+	IoctlStorageCheckVerify    = (IoctlStorageBase << 16) | (FileReadAccess << 14) | (StorageCheckVerify << 2) | MethodBuffered
+
 	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw
 	volumeOptReadOnly = uint32(0x00080000)
 	volumeCompressed  = uint32(0x00008000)
@@ -505,8 +509,22 @@ func (l *CheckDrivesize) setVolume(requiredDrives map[string]map[string]string, 
 	}
 
 	mounted := "0"
-	if letter != "" {
-		mounted = "1"
+	if drive != "" {
+		szDevice := fmt.Sprintf(`\\.\%s`, strings.TrimSuffix(drive, "\\"))
+		szPtr, err := syscall.UTF16PtrFromString(szDevice)
+		if err == nil {
+			handle, err := windows.CreateFile(szPtr, 0, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, 0, 0)
+			if err == nil {
+				defer func() {
+					LogDebug(windows.CloseHandle(handle))
+				}()
+				var num uint32
+				err = windows.DeviceIoControl(handle, IoctlStorageCheckVerify, nil, 0, nil, 0, &num, nil)
+				if err == nil {
+					mounted = "1"
+				}
+			}
+		}
 	}
 
 	if drive != "" {

--- a/pkg/snclient/check_drivesize_windows.go
+++ b/pkg/snclient/check_drivesize_windows.go
@@ -441,7 +441,7 @@ func (l *CheckDrivesize) setVolumes(requiredDrives map[string]map[string]string)
 // takes a GUID path of a volume, then finds its path name.
 // it may or may not be mounted directly on a drive letter
 //
-//nolint:funlen // there are a lot of entry attributes
+//nolint:funlen,nestif // there are a lot of entry attributes, error checks while determining 'mounted' attribute
 func (l *CheckDrivesize) setVolume(requiredDrives map[string]map[string]string, volumeGUIDPath string, buffer []uint16) {
 	volPtr, err := syscall.UTF16PtrFromString(volumeGUIDPath)
 	if err != nil {
@@ -503,27 +503,21 @@ func (l *CheckDrivesize) setVolume(requiredDrives map[string]map[string]string, 
 	}
 
 	mounted := "0"
-	var pathNameUTF16 *uint16
-	if volumePathName == "" {
+	if volumePathName != "" {
+		pathNameUTF16, err := syscall.UTF16PtrFromString(volumePathName)
+		if err != nil {
+			log.Tracef("error converting to utf16 string, volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
+		} else {
+			err = windows.GetVolumeInformation(pathNameUTF16, nil, 0, nil, nil, nil, nil, 0)
+			if err != nil {
+				log.Tracef("GetVolumeInformation failed for volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
+			} else {
+				mounted = "1"
+			}
+		}
+	} else {
 		log.Tracef("No path exists for volume: '%s', assuming it is unmounted", volumeGUIDPath)
-
-		goto mounteddiscovery
 	}
-	pathNameUTF16, err = syscall.UTF16PtrFromString(volumePathName)
-	if err != nil {
-		log.Tracef("error converting to utf16 string, volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
-
-		goto mounteddiscovery
-	}
-	err = windows.GetVolumeInformation(pathNameUTF16, nil, 0, nil, nil, nil, nil, 0)
-	if err != nil {
-		log.Tracef("GetVolumeInformation failed for volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
-
-		goto mounteddiscovery
-	}
-	mounted = "1"
-
-mounteddiscovery:
 
 	if drive != "" {
 		for _, existingDrive := range requiredDrives {

--- a/pkg/snclient/check_drivesize_windows.go
+++ b/pkg/snclient/check_drivesize_windows.go
@@ -28,10 +28,6 @@ const (
 	IoctlStorageGetMediaTypesEX = (IoctlStorageBase << 16) | (FileAnyAccess << 14) | (StorageGetMediaTypesEX << 2) | MethodBuffered
 	MaxMediaTypes               = 128
 
-	FileReadAccess             = 0x0001
-	StorageCheckVerify         = 0x0200
-	IoctlStorageCheckVerify    = (IoctlStorageBase << 16) | (FileReadAccess << 14) | (StorageCheckVerify << 2) | MethodBuffered
-
 	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw
 	volumeOptReadOnly = uint32(0x00080000)
 	volumeCompressed  = uint32(0x00008000)
@@ -473,15 +469,13 @@ func (l *CheckDrivesize) setVolume(requiredDrives map[string]map[string]string, 
 	}
 	volumePathName := syscall.UTF16ToString(buffer)
 
-	if volumePathName == "" {
-		log.Tracef("volume has no path name, using GUID path as path: %s", volumeGUIDPath)
-		volumePathName = volumeGUIDPath
-	}
-
 	// entry attributes
 	volumeID := volumeGUIDPath
 
 	name := volumePathName
+	if name == "" {
+		name = volumeGUIDPath
+	}
 
 	drive, isDrive, _ := cleanupPathString(volumePathName)
 	if !isDrive {
@@ -509,23 +503,27 @@ func (l *CheckDrivesize) setVolume(requiredDrives map[string]map[string]string, 
 	}
 
 	mounted := "0"
-	if drive != "" {
-		szDevice := fmt.Sprintf(`\\.\%s`, strings.TrimSuffix(drive, "\\"))
-		szPtr, err := syscall.UTF16PtrFromString(szDevice)
-		if err == nil {
-			handle, err := windows.CreateFile(szPtr, 0, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, 0, 0)
-			if err == nil {
-				defer func() {
-					LogDebug(windows.CloseHandle(handle))
-				}()
-				var num uint32
-				err = windows.DeviceIoControl(handle, IoctlStorageCheckVerify, nil, 0, nil, 0, &num, nil)
-				if err == nil {
-					mounted = "1"
-				}
-			}
-		}
+	var pathNameUTF16 *uint16
+	if volumePathName == "" {
+		log.Tracef("No path exists for volume: '%s', assuming it is unmounted", volumeGUIDPath)
+
+		goto mounteddiscovery
 	}
+	pathNameUTF16, err = syscall.UTF16PtrFromString(volumePathName)
+	if err != nil {
+		log.Tracef("error converting to utf16 string, volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
+
+		goto mounteddiscovery
+	}
+	err = windows.GetVolumeInformation(pathNameUTF16, nil, 0, nil, nil, nil, nil, 0)
+	if err != nil {
+		log.Tracef("GetVolumeInformation failed for volume: '%s' with path: '%s', assuming it is unmounted", volumeGUIDPath, volumePathName)
+
+		goto mounteddiscovery
+	}
+	mounted = "1"
+
+mounteddiscovery:
 
 	if drive != "" {
 		for _, existingDrive := range requiredDrives {


### PR DESCRIPTION
check_drivesize has two ways for discovering drives, one uses gopsutil function disk.Partitions and other uses volume discovery, largely written specifically in snclient using win32 apis

rework volume discovery path and fix mounted getting the wrong number for removable , CD , DVD and floppy drives.

mounted is set as default to 0. if the volume has a path name, and GetVolumeInformation can be called, assume that it is mounted. This is better than setting mounted to 1 if there is a letter, which it was previously doing

There could be floppy, CD, or DVD disks that do not have any media present. These should not be mounted.

There are also other volumes available, but not mounted. These are volumes that windows can read - FAT32, NTFS etc. but are not mounted anywhere.

Some of the volume tests and their mounted results

.\snclient.windows.amd64.exe -vvv --logfile stdout run check_drivesize drive=all-volumes critical='used_pct gt 99' warning='used_pct gt 99' show-all detail-syntax="%(drive_or_name_or_id) - %(mounted)"


Windows Recovery Partition, likely FAT32 but not mounted by default
```
[14:27:22.548][T][check_drivesize_windows:508] No path exists for volume: '\\?\Volume{729051a5-f05b-4873-86c5-46357e657ceb}\', assuming it is unmounted
```

GUID Partition Table - FAT32 external drive , tested with two of them

```

GUID Partition Table - FAT32 external drive is inserted, and assigned letter J:
J:\ - 1

GUID Partition Table - FAT32 external drive is inserted, and drive is ejected
no mention of the volume in the logs

GUID Partition Table - FAT32 external drive is inserted, and letter is unassigned
[11:05:18.117][T][check_drivesize_windows:508] No path exists for volume: '\\?\Volume{a39887ce-e2d3-4aad-a9e3-502c2042470f}\', assuming it is unmounted
[11:05:18.117][T][check_drivesize_windows:508] No path exists for volume: '\\?\Volume{6a1835e1-8671-11f1-b39e-6045cba0e478}\', assuming it is unmounted

GUID Partition Table - FAT32 external drive is inserted, mounted to C:\mounttest
C:\mounttest\ - 1
```


GUID Partition Table - Ext4 external drive

```
GUID Partition Tavble - ext4 formatted external drive is inserted
windows disk management tool , lists the disk, sees the partition but no mention of volume
```

Citrix Software Based Volume
```
[14:29:33.470][T][check_drivesize_windows:513] GetVolumeInformation failed for volume: '\\?\Volume{589e6702-0000-0000-0000-010000000000}\' with path: 'C:\Program Files\Citrix\PvsVm\Service\PersistedData\', assuming it is unmounted
OK - C:\Program Files\Citrix\PvsVm\Service\PersistedData\ - 0
```

Virtualized DVD Drive
```
[14:29:33.470][T][check_drivesize_windows:513] GetVolumeInformation failed for volume: '\\?\Volume{589e6702-0000-0000-0000-010000000000}\' with path: 'C:\Program Files\Citrix\PvsVm\Service\PersistedData\', assuming it is unmounted
 D:\ - 0
```