### PR TITLE
Builtin checks expose context logger with string key

### DIFF
--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -8,9 +8,14 @@ import (
 
 type loggerCtxKey struct{}
 
-//nolint:ireturn // context helpers must return context.Context by convention
+const (
+	loggerCtxKey2 string = "github.com/consol-monitoring/snclient/pkg/utils.Logger"
+)
+
+//nolint:ireturn,staticcheck,revive,lll // context helpers must return context.Context by convention . If the context is used in a package that does not have access to loggerCtxKey, it can use the loggerCtxKey2
 func ContextWithLogger(ctx context.Context, log *factorlog.FactorLog) context.Context {
-	return context.WithValue(ctx, loggerCtxKey{}, log)
+	return context.WithValue(context.WithValue(ctx, loggerCtxKey{}, log),
+		loggerCtxKey2, log)
 }
 
 func LoggerFromContext(ctx context.Context) *factorlog.FactorLog {

--- a/t/01_cmd_test.go
+++ b/t/01_cmd_test.go
@@ -52,9 +52,9 @@ func TestCommandFlags(t *testing.T) {
 
 	runCmd(t, &cmd{
 		Cmd:     bin,
-		Args:    []string{"-vv", "run", "check_http", "-H", "localhost", "-p", "60666", "--uri=/test"},
-		Like:    []string{`HTTP CRITICAL`, `command: check_http`},
-		ErrLike: []string{`GET`},
+		Args:    []string{"-v", "run", "check_http", "-H", "localhost", "-p", "60666", "--uri=/test"},
+		Like:    []string{`HTTP CRITICAL`},
+		ErrLike: []string{``},
 		Exit:    2,
 	})
 }


### PR DESCRIPTION
logger context: expose snclient logger instance with a second key of string type
    
loggerCtxKey is a struct{} type used to pack logger inside. this can be accessed if snclient package is imported
    
loggerCtxKey2 is a new string type key with value "github.com/consol-monitoring/snclient/pkg/utils.Logger" , specific to the snclient logger.
    
adding objects to the context with string keys is not recommended in general, but if the pkg/snclient is not imported in other package (likely due to circular dependency problem) , they can use the string value to get the logger instance. the string is very specific to snclient already.
    
this is better than writing to the output buffer and contaminating it. output buffer should only be used to communicate check results
    
this is intended to be used with check_http, which has its own package
    
tested and works, even though the filename is wrong as it uses the filename in the check_http_go package

but need to merge check_http_go PR first:

https://github.com/sni/check_http_go/pull/5


```
./snclient -vvv --verbose --logfile stdout run check_http --hostname google.com --certificate=1000,500
...
[16:27:05.896][T][check:117] extracting logger from context using snclient logger specific key result: true
[16:27:05.936][T][check:117] certificate check: cert '*.google.com' from 'WR2' expires in 55 days (critical)
[16:27:05.936][T][check:117] certificate check: cert 'WR2' from 'GTS Root R1' expires in 938 days (warning)
[16:27:05.936][T][check:117] certificate check: cert 'GTS Root R1' from 'GlobalSign Root CA' expires in 549 days (warning)
[16:27:05.936][T][check:117] subcheck 0 | code: 2 | importance: 151 | msg: HTTP CRITICAL - x509 certificate '*.google.com' from 'WR2' is valid until Mon 21 Sep 2026 08:37:24 AM UTC +0000 (expires in 55 days)
[16:27:05.936][T][check:117] subcheck 1 | code: 1 | importance: 251 | msg: HTTP WARNING - x509 certificate 'WR2' from 'GTS Root R1' is valid until Tue 20 Feb 2029 02:00:00 PM UTC +0000 (expires in 938 days)
[16:27:05.936][T][check:117] subcheck 2 | code: 1 | importance: 351 | msg: HTTP WARNING - x509 certificate 'GTS Root R1' from 'GlobalSign Root CA' is valid until Fri 28 Jan 2028 12:00:42 AM UTC +0000 (expires in 549 days)
[16:27:05.936][T][check:117] subcheck 3 | code: 0 | importance: 152 | msg: HTTP OK - x509 certificate '*.google.com' from 'WR2' has its validity start time in the past (valid from Mon 29 Jun 2026 08:37:25 AM UTC +0000)
[16:27:05.936][T][check:117] subcheck 4 | code: 0 | importance: 153 | msg: HTTP OK - x509 certificate '*.google.com' from 'WR2' uses strong signature algorithm SHA256-RSA
[16:27:05.936][T][check:117] subcheck 5 | code: 0 | importance: 252 | msg: HTTP OK - x509 certificate 'WR2' from 'GTS Root R1' has its validity start time in the past (valid from Wed 13 Dec 2023 09:00:00 AM UTC +0000)
[16:27:05.936][T][check:117] subcheck 6 | code: 0 | importance: 253 | msg: HTTP OK - x509 certificate 'WR2' from 'GTS Root R1' uses strong signature algorithm SHA256-RSA
[16:27:05.936][T][check:117] subcheck 7 | code: 0 | importance: 352 | msg: HTTP OK - x509 certificate 'GTS Root R1' from 'GlobalSign Root CA' has its validity start time in the past (valid from Fri 19 Jun 2020 12:00:42 AM UTC +0000)
[16:27:05.936][T][check:117] subcheck 8 | code: 0 | importance: 353 | msg: HTTP OK - x509 certificate 'GTS Root R1' from 'GlobalSign Root CA' uses strong signature algorithm SHA256-RSA
```