### PR TITLE
check_mailq: use postqueue JSON output

### DIFF
--- a/docs/checks/commands/check_mailq.md
+++ b/docs/checks/commands/check_mailq.md
@@ -16,6 +16,15 @@ Checks the mailq.
 |:-------:|:------------------:|:------------------:|:------------------:|
 |         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
+Postfix queues are read using `postqueue -j`. The user running SNClient must be
+allowed by `authorized_mailq_users` (default: `static:anyone`). For restricted
+setups, add the user to the list, for example `authorized_mailq_users = snclient`.
+
+Active messages are reported as `active`; all other queue states, including
+`hold`, are reported as `deferred`. If `postqueue` fails, the check falls back
+to reading the `active` and `deferred` directories below `queue_directory`. It
+returns `UNKNOWN` if these directories cannot be read.
+
 ## Examples
 
 ### Default Check

--- a/docs/checks/commands/check_mailq.md
+++ b/docs/checks/commands/check_mailq.md
@@ -16,15 +16,6 @@ Checks the mailq.
 |:-------:|:------------------:|:------------------:|:------------------:|
 |         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
-Postfix queues are read using `postqueue -j`. The user running SNClient must be
-allowed by `authorized_mailq_users` (default: `static:anyone`). For restricted
-setups, add the user to the list, for example `authorized_mailq_users = snclient`.
-
-Active messages are reported as `active`; all other queue states, including
-`hold`, are reported as `deferred`. If `postqueue` fails, the check falls back
-to reading the `active` and `deferred` directories below `queue_directory`. It
-returns `UNKNOWN` if these directories cannot be read.
-
 ## Examples
 
 ### Default Check

--- a/pkg/snclient/check_mailq.go
+++ b/pkg/snclient/check_mailq.go
@@ -2,10 +2,13 @@ package snclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/consol-monitoring/snclient/pkg/convert"
 )
@@ -89,6 +92,15 @@ func (l *CheckMailq) addQueues(ctx context.Context, check *CheckData) (err error
 
 // get queue from postfix
 func (l *CheckMailq) addPostfix(ctx context.Context, check *CheckData) error {
+	entry, err := l.postfixQueueStats(ctx)
+	if err == nil {
+		check.listData = append(check.listData, entry)
+		l.addMetrics(check, entry)
+
+		return nil
+	}
+	log.Debugf("checking postfix queue with postqueue failed: %s", err.Error())
+
 	queueFolder, stderr, rc, err := l.snc.execCommand(ctx, "postconf -h queue_directory", l.snc.getBuiltinCmdTimeout())
 	if err != nil {
 		return fmt.Errorf("postfix: postconf failed: %s\n%s", err.Error(), stderr)
@@ -96,7 +108,7 @@ func (l *CheckMailq) addPostfix(ctx context.Context, check *CheckData) error {
 	if rc != 0 {
 		return fmt.Errorf("postconf failed: %s\n%s", queueFolder, stderr)
 	}
-	entry := l.defaultEntry("postfix")
+	entry = l.defaultEntry("postfix")
 
 	for _, queue := range []string{"active", "deferred"} {
 		entry[queue] = "0"
@@ -124,6 +136,49 @@ func (l *CheckMailq) addPostfix(ctx context.Context, check *CheckData) error {
 	l.addMetrics(check, entry)
 
 	return nil
+}
+
+func (l *CheckMailq) postfixQueueStats(ctx context.Context) (map[string]string, error) {
+	output, stderr, rc, err := l.snc.execCommand(ctx, "postqueue -j", l.snc.getBuiltinCmdTimeout())
+	if err != nil {
+		return nil, fmt.Errorf("postqueue failed: %s\n%s", err.Error(), stderr)
+	}
+	if rc != 0 {
+		return nil, fmt.Errorf("postqueue failed: %s\n%s", output, stderr)
+	}
+
+	var active, activeSize, deferred, deferredSize int64
+	decoder := json.NewDecoder(strings.NewReader(output))
+	for {
+		var item struct {
+			QueueName   string `json:"queue_name"`
+			MessageSize int64  `json:"message_size"`
+		}
+		err := decoder.Decode(&item)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not parse postqueue output: %w", err)
+		}
+
+		switch item.QueueName {
+		case "active":
+			active++
+			activeSize += item.MessageSize
+		default:
+			deferred++
+			deferredSize += item.MessageSize
+		}
+	}
+
+	entry := l.defaultEntry("postfix")
+	entry["active"] = fmt.Sprintf("%d", active)
+	entry["active_size"] = fmt.Sprintf("%d", activeSize)
+	entry["deferred"] = fmt.Sprintf("%d", deferred)
+	entry["deferred_size"] = fmt.Sprintf("%d", deferredSize)
+
+	return entry, nil
 }
 
 func (l *CheckMailq) defaultEntry(source string) map[string]string {

--- a/pkg/snclient/check_mailq_test.go
+++ b/pkg/snclient/check_mailq_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package snclient
 
 import (

--- a/pkg/snclient/check_mailq_test.go
+++ b/pkg/snclient/check_mailq_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//nolint:lll // preserve realistic postqueue JSON output with one queue entry per line
 func TestCheckMailqPostfixJSON(t *testing.T) {
 	snc := StartTestAgent(t, "")
 

--- a/pkg/snclient/check_mailq_test.go
+++ b/pkg/snclient/check_mailq_test.go
@@ -1,0 +1,36 @@
+package snclient
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckMailqPostfixJSON(t *testing.T) {
+	snc := StartTestAgent(t, "")
+
+	// mock postqueue with anonymized output from a real postfix queue
+	tmpPath := MockSystemUtilities(t, map[string]string{
+		"postqueue": `
+{"queue_name": "active", "queue_id": "AAAAAAAAAAA", "arrival_time": 1785318106, "message_size": 306, "forced_expire": false, "sender": "sender@example.invalid", "recipients": [{"orig_address": "", "address": "active@example.invalid"}]}
+{"queue_name": "deferred", "queue_id": "BBBBBBBBBBB", "arrival_time": 1785318106, "message_size": 2552, "forced_expire": false, "sender": "MAILER-DAEMON", "recipients": [{"orig_address": "", "address": "deferred@example.invalid", "delay_reason": "alias database unavailable"}]}
+{"queue_name": "hold", "queue_id": "CCCCCCCCCCC", "arrival_time": 1785258307, "message_size": 414, "forced_expire": false, "sender": "MAILER-DAEMON", "recipients": [{"orig_address": "", "address": "postqueue-test@example.invalid", "delay_reason": "Host or domain name not found"}]}`,
+	})
+	defer os.RemoveAll(tmpPath)
+
+	res := snc.RunCheck("check_mailq", []string{"mta=postfix"})
+	assert.Equalf(t, CheckExitWarning, res.State, "state Warning")
+	assert.Equalf(t,
+		"WARNING - postfix: active 1 / deferred 2 |'active'=1;5;10;0 'active_size'=306B;10000000;20000000;0 'deferred'=2;0;10;0 'deferred_size'=2966B;10000000;20000000;0",
+		string(res.BuildPluginOutput()), "output matches")
+
+	MockSystemUtilities(t, map[string]string{"postqueue": ""})
+	res = snc.RunCheck("check_mailq", []string{"mta=postfix"})
+	assert.Equalf(t, CheckExitOK, res.State, "state OK")
+	assert.Equalf(t,
+		"OK - postfix: active 0 / deferred 0 |'active'=0;5;10;0 'active_size'=0B;10000000;20000000;0 'deferred'=0;0;10;0 'deferred_size'=0B;10000000;20000000;0",
+		string(res.BuildPluginOutput()), "output matches")
+
+	StopTestAgent(t, snc)
+}


### PR DESCRIPTION
Read Postfix queue statistics through postqueue -j so the check does not require direct access to queue directories. The existing directory-based mode remains active as a fallback when postqueue fails.

Tested against real postfix postqueue json output. Draft status as it could need some more real life testing before merging

Fixes #431