### PR TITLE
check_drivesize: ai assisted, blacklist generallized conditions in thresholdString better and small used_pct fix when total=0

### DIFF
--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -353,6 +353,13 @@ func (l *CheckDrivesize) disableGenerallizedConditionsForDrive(driveName string,
 		// specialized: <drive> <cut> %    generalized: <cut>
 		check.disableGenerallizedConditionsUsingAttributes(entry, `%[2]s %[3]s %%`, `%[3]s`, []string{attribute.name}, driveName, cut)
 	}
+
+	// Also handle conditions that use "drive" keyword in a subcondition e.g:
+	// "drive eq '/boot' and used_pct gt 85"
+	// When such a specialized condition exists, blacklist generic conditions (without "drive" keyword) so they dont work on this entry
+	check.warnThreshold.blacklistConditionsNotUsingKeywordIfKeywordIsActive("drive", entry)
+	check.critThreshold.blacklistConditionsNotUsingKeywordIfKeywordIsActive("drive", entry)
+	check.okThreshold.blacklistConditionsNotUsingKeywordIfKeywordIsActive("drive", entry)
 }
 
 func (l *CheckDrivesize) addMetrics(metricPrefix string, drive map[string]string, check *CheckData, usage *disk.UsageStat, magic float64) {

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -490,7 +490,7 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 	}
 
 	freePct := float64(0)
-	usedPct := float64(0)
+	usedPct := float64(100)
 	if total > 0 {
 		freePct = float64(usage.Free) * 100 / float64(total)
 		usedPct = float64(usage.Used) * 100 / float64(total)

--- a/pkg/snclient/check_drivesize_test.go
+++ b/pkg/snclient/check_drivesize_test.go
@@ -149,3 +149,35 @@ func TestRootDriveSpecializedDriveConditions(t *testing.T) {
 
 	StopTestAgent(t, snc)
 }
+
+func TestDrivesizeSpecializedDriveConditionWithUsedPct(t *testing.T) {
+	snc := StartTestAgent(t, "")
+
+	// Generic condition would trigger (used_pct > 0 always true), but specialized
+	// critical with drive eq '/' and unreachable threshold (> 100) should filter it out
+	res := snc.RunCheck("check_drivesize", []string{
+		"drive=/", "critical=used_pct gt 0", "warning=none",
+		"critical=drive eq '/' and used_pct gt 100",
+	})
+	assert.Equalf(t, CheckExitOK, res.State, "state should be OK")
+
+	// Without any specialized condition, generic used_pct should trigger
+	res = snc.RunCheck("check_drivesize", []string{"drive=/", "critical=used_pct gt 0", "warning=none"})
+	assert.Equalf(t, CheckExitCritical, res.State, "state should be CRITICAL")
+
+	// Specialized condition only in warning: generic critical should still trigger
+	res = snc.RunCheck("check_drivesize", []string{
+		"drive=/", "critical=used_pct gt 0", "warning=none",
+		"warning=drive eq '/' and used_pct gt 100",
+	})
+	assert.Equalf(t, CheckExitCritical, res.State, "state should be CRITICAL")
+
+	// Specialized condition only in critical: generic warning should still trigger
+	res = snc.RunCheck("check_drivesize", []string{
+		"drive=/", "warning=used_pct gt 0", "critical=none",
+		"critical=drive eq '/' and used_pct gt 100",
+	})
+	assert.Equalf(t, CheckExitWarning, res.State, "state should be WARNING")
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/condition.go
+++ b/pkg/snclient/condition.go
@@ -1490,6 +1490,25 @@ func (cl *ConditionList) filterForSpecializedKeyword(keyword string, entry map[s
 	return result
 }
 
+// blacklistConditionsNotUsingKeywordIfKeywordIsActive blacklists conditions that do not use the keyword, but only if keyword itself is used in the list and matches the enetry.
+// This is used when at least one condition in the list has the keyword AND matches the entry, indicating a specialized condition is present.
+// In that case, generic conditions (without the keyword) should not apply to this entry, so they will be blacklisted.
+func (cl *ConditionList) blacklistConditionsNotUsingKeywordIfKeywordIsActive(keyword string, entry map[string]string) {
+	_, keywordPresentAndPermitsEntry, conditionThatPermitsEntry := cl.ifKeywordIsPresentAndPermitsEntry(keyword, entry)
+	if !keywordPresentAndPermitsEntry {
+		return
+	}
+
+	for _, condition := range *cl {
+		keywords, _ := condition.GetListOfKeywords()
+		if !slices.Contains(keywords, keyword) {
+			condition.blacklistData = append(condition.blacklistData, entry)
+			log.Tracef("Blacklisting entry for condition lacking '%s' keyword, specialized condition: %q , blacklisted condition: %q , entry: %q",
+				keyword, conditionThatPermitsEntry.DetailedString(), condition.DetailedString(), entry)
+		}
+	}
+}
+
 // returns at first encounter of error
 // calls c.RunFuncRecursively to the conditions in ConditionList
 func (cl *ConditionList) applyFuncToConditions(_func func(c *Condition) error) error {

--- a/pkg/snclient/condition.go
+++ b/pkg/snclient/condition.go
@@ -1490,7 +1490,7 @@ func (cl *ConditionList) filterForSpecializedKeyword(keyword string, entry map[s
 	return result
 }
 
-// blacklistConditionsNotUsingKeywordIfKeywordIsActive blacklists conditions that do not use the keyword, but only if keyword itself is used in the list and matches the enetry.
+// blacklistConditionsNotUsingKeywordIfKeywordIsActive blacklists conditions that do not use the keyword, but only if keyword itself is used in the list and matches the entry.
 // This is used when at least one condition in the list has the keyword AND matches the entry, indicating a specialized condition is present.
 // In that case, generic conditions (without the keyword) should not apply to this entry, so they will be blacklisted.
 func (cl *ConditionList) blacklistConditionsNotUsingKeywordIfKeywordIsActive(keyword string, entry map[string]string) {


### PR DESCRIPTION
if specialized condition list of form  'drive op X and attriubute op Y' are present in the threshold, detect those as well

it was previously only detecting '[drive] used %' and similar percentage metrics as specialized and then blacklisting 'used_pct'

now it can detect conditions that contain 'drive' keyword and match the entry. other conditions without 'drive' keyword are blacklisted

for information, blacklisting works on entry checks - not metric checks. metrics add conditions after the filtering based on specialized/generallized drives. they are not using blacklists/whitelists. they were already prefiltering to the specialized conditions if present


---

check_drivesize: assume default used_pct to be 100 when adding drive details

only if the drive reports a total size > 0 the free_pct from its 0 and used_pct from its default 100 are calculated truthfully.

pseudo drives like /proc/fs/nfsd and kde kio drives like /run/user/1000/kio-fuse-xxxx reported total=0. the metric checks assumed used_pct is 100 in addBytePercentMetrics with an override for total=0.

the entry should use the same value 100 for its used_pct metric - so that the entry raises the critical and warning threshold just like metric itself and gets listed in the output