### PR TITLE
check_drivesize: improve '[drive] used_pct' and '[drive] used_pct' conditions

### DIFF
--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -483,6 +483,8 @@ func (l *CheckDrivesize) addTotalUserMacros(drive map[string]string) {
 }
 
 // Uses the disk.UsageStat argument and adds its data to the drive
+//
+//nolint:funlen // there are many attributes to add
 func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]string, usage *disk.UsageStat, magic float64) {
 	total := usage.Total
 	if !l.freespaceIgnoreReserved {
@@ -537,11 +539,11 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 
 	// Add drive-prefixed copies of metric keys so conditions like "/boot used % > 10" can match the entry during entry-level checks.
 	prefixedKeys := make(map[string]string)
-	for k, v := range drive {
-		if strings.HasPrefix(k, "_") {
+	for attributeKey, value := range drive {
+		if strings.HasPrefix(attributeKey, "_") {
 			continue
 		}
-		switch k {
+		switch attributeKey {
 		case "drive", "drive_or_id", "drive_or_name", "drive_or_name_or_id",
 			"id", "name", "fstype", "flags", "mounted",
 			"media_type", "type", "readable", "writable", "removable",
@@ -549,7 +551,7 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 			"localised_remote_path", "perflabel_prefix", "letter", "opts":
 			continue
 		}
-		prefixedKeys[metricPrefix+" "+k] = v
+		prefixedKeys[metricPrefix+" "+attributeKey] = value
 	}
 	maps.Copy(drive, prefixedKeys)
 }

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -483,8 +483,6 @@ func (l *CheckDrivesize) addTotalUserMacros(drive map[string]string) {
 }
 
 // Uses the disk.UsageStat argument and adds its data to the drive
-//
-//nolint:funlen // there are many attributes to add
 func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]string, usage *disk.UsageStat, magic float64) {
 	total := usage.Total
 	if !l.freespaceIgnoreReserved {
@@ -536,24 +534,6 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 	}
 
 	l.addMetrics(metricPrefix, drive, check, usage, magic)
-
-	// Add drive-prefixed copies of metric keys so conditions like "/boot used % > 10" can match the entry during entry-level checks.
-	prefixedKeys := make(map[string]string)
-	for attributeKey, value := range drive {
-		if strings.HasPrefix(attributeKey, "_") {
-			continue
-		}
-		switch attributeKey {
-		case "drive", "drive_or_id", "drive_or_name", "drive_or_name_or_id",
-			"id", "name", "fstype", "flags", "mounted",
-			"media_type", "type", "readable", "writable", "removable",
-			"erasable", "hotplug", "remote_name", "persistent",
-			"localised_remote_path", "perflabel_prefix", "letter", "opts":
-			continue
-		}
-		prefixedKeys[metricPrefix+" "+attributeKey] = value
-	}
-	maps.Copy(drive, prefixedKeys)
 }
 
 func (l *CheckDrivesize) getFlagNames(drive map[string]string) []string {

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -501,14 +501,18 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 	drive["used"] = humanize.IBytesF(uint64(magic*float64(usage.Used)), 3)
 	drive["used_bytes"] = fmt.Sprintf("%d", uint64(magic*float64(usage.Used)))
 	drive["used_pct"] = fmt.Sprintf("%f", usedPct)
+	drive["used %"] = fmt.Sprintf("%f", usedPct)
 	drive["free"] = humanize.IBytesF(uint64(magic*float64(usage.Free)), 3)
 	drive["free_bytes"] = fmt.Sprintf("%d", uint64(magic*float64(usage.Free)))
 	drive["free_pct"] = fmt.Sprintf("%f", freePct)
+	drive["free %"] = fmt.Sprintf("%f", freePct)
 	drive["inodes_total"] = fmt.Sprintf("%d", usage.InodesTotal)
 	drive["inodes_used"] = fmt.Sprintf("%d", usage.InodesUsed)
 	drive["inodes_free"] = fmt.Sprintf("%d", usage.InodesFree)
 	drive["inodes_used_pct"] = fmt.Sprintf("%f", usage.InodesUsedPercent)
+	drive["inodes_used %"] = fmt.Sprintf("%f", usage.InodesUsedPercent)
 	drive["inodes_free_pct"] = fmt.Sprintf("%f", 100-usage.InodesUsedPercent)
+	drive["inodes_free %"] = fmt.Sprintf("%f", 100-usage.InodesUsedPercent)
 	if drive["fstype"] == "" {
 		drive["fstype"] = usage.Fstype
 	}

--- a/pkg/snclient/check_drivesize.go
+++ b/pkg/snclient/check_drivesize.go
@@ -534,6 +534,24 @@ func (l *CheckDrivesize) addDriveSizeDetails(check *CheckData, drive map[string]
 	}
 
 	l.addMetrics(metricPrefix, drive, check, usage, magic)
+
+	// Add drive-prefixed copies of metric keys so conditions like "/boot used % > 10" can match the entry during entry-level checks.
+	prefixedKeys := make(map[string]string)
+	for k, v := range drive {
+		if strings.HasPrefix(k, "_") {
+			continue
+		}
+		switch k {
+		case "drive", "drive_or_id", "drive_or_name", "drive_or_name_or_id",
+			"id", "name", "fstype", "flags", "mounted",
+			"media_type", "type", "readable", "writable", "removable",
+			"erasable", "hotplug", "remote_name", "persistent",
+			"localised_remote_path", "perflabel_prefix", "letter", "opts":
+			continue
+		}
+		prefixedKeys[metricPrefix+" "+k] = v
+	}
+	maps.Copy(drive, prefixedKeys)
 }
 
 func (l *CheckDrivesize) getFlagNames(drive map[string]string) []string {

--- a/pkg/snclient/check_drivesize_test.go
+++ b/pkg/snclient/check_drivesize_test.go
@@ -199,3 +199,41 @@ func TestDrivesizeUsedPercentKeyword(t *testing.T) {
 
 	StopTestAgent(t, snc)
 }
+
+func TestDrivesizeSpecializedEntryInProblemList(t *testing.T) {
+	snc := StartTestAgent(t, "")
+
+	// Specialized critical for / with unreachable threshold:
+	// drive eq '/' and used_pct gt 100
+	// entry should not be in problem_list, no critical triggered.
+	res := snc.RunCheck("check_drivesize", []string{
+		"drive=/",
+		"warning=none",
+		"critical='used %' gt 88",
+		"crit=drive eq '/' and used_pct gt 100",
+	})
+	assert.Equalf(t, CheckExitOK, res.State, "state should be OK")
+	assert.Containsf(t, string(res.BuildPluginOutput()), "OK - ", "output should be OK")
+
+	// Specialized critical for / with reachable threshold:
+	// drive eq '/' and used_pct gt 0
+	// entry should appear in problem_list, exit state CRITICAL.
+	res = snc.RunCheck("check_drivesize", []string{
+		"drive=/",
+		"warning=none",
+		"critical='used %' gt 88",
+		"crit=drive eq '/' and used_pct gt 0",
+	})
+	assert.Equalf(t, CheckExitCritical, res.State, "state should be CRITICAL")
+	output := string(res.BuildPluginOutput())
+	assert.Containsf(t, output, "CRITICAL - / ", "problem list should contain / entry")
+	// Perfdata thresholds: specialized critical (0%) overrides generic (88%), warning is empty (none)
+	assert.Regexpf(
+		t,
+		`/ used %'=[\d.]+%;;0;0;100`,
+		output,
+		"perfdata should use specialized critical threshold 0",
+	)
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/check_drivesize_test.go
+++ b/pkg/snclient/check_drivesize_test.go
@@ -181,3 +181,21 @@ func TestDrivesizeSpecializedDriveConditionWithUsedPct(t *testing.T) {
 
 	StopTestAgent(t, snc)
 }
+
+func TestDrivesizeUsedPercentKeyword(t *testing.T) {
+	snc := StartTestAgent(t, "")
+
+	// 'used %' gt 0 should always trigger
+	res := snc.RunCheck("check_drivesize", []string{"drive=/", "warning=none", "critical='used %' gt 0"})
+	assert.Equalf(t, CheckExitCritical, res.State, "state should be CRITICAL")
+
+	// 'used %' gt 100 should never trigger
+	res = snc.RunCheck("check_drivesize", []string{"drive=/", "warning=none", "critical='used %' gt 100"})
+	assert.Equalf(t, CheckExitOK, res.State, "state should be OK")
+
+	// 'used %' keyword with warning
+	res = snc.RunCheck("check_drivesize", []string{"drive=/", "warning='used %' gt 0", "critical=none"})
+	assert.Equalf(t, CheckExitWarning, res.State, "state should be WARNING")
+
+	StopTestAgent(t, snc)
+}

--- a/pkg/snclient/checkdata.go
+++ b/pkg/snclient/checkdata.go
@@ -238,11 +238,10 @@ func (cd *CheckData) finalizeOutput() (*CheckResult, error) {
 	// Run a separate check on the macros
 	log.Tracef("checking warning, critical, and ok thresholds on check macros")
 	cd.Check(finalMacros, cd.warnThreshold, cd.critThreshold, cd.okThreshold)
-	cd.setStateFromMaps(finalMacros)
-	// Metrics are checked last, which also sets the final state
 	log.Tracef("checking warning, critical, and ok thresholds on check metrics")
 	// metrics save their own warning and critical thresholds, but ok thresholds come from check itself
 	cd.CheckMetrics(cd.okThreshold)
+	cd.setStateFromMaps(finalMacros)
 
 	switch {
 	case cd.result.Output != "":
@@ -506,6 +505,9 @@ func (cd *CheckData) CheckMetrics(okCond ConditionList) {
 		if state > CheckExitOK {
 			log.Debugf("metric.Name: '%s', metric.ThresholdName: '%s', metric.Value: '%v', gave non-ok state: %s", metric.Name, metric.ThresholdName, metric.Value, convert.StateString(state))
 			cd.result.EscalateStatus(state)
+			if metric.Entry != nil {
+				metric.Entry["_state"] = fmt.Sprintf("%d", state)
+			}
 		}
 	}
 }

--- a/pkg/snclient/condition.go
+++ b/pkg/snclient/condition.go
@@ -976,7 +976,7 @@ func (c *Condition) TransformMultipleKeywords(srcKeywords []string, targetKeywor
 	}
 	c.keyword = targetKeyword
 	switch {
-	case strings.HasSuffix(found, "_pct"):
+	case strings.HasSuffix(found, "_pct"), strings.HasSuffix(found, " %"):
 		c.unit = "%"
 	case strings.HasSuffix(found, "_bytes"):
 		c.unit = "B"

--- a/pkg/utils/asciiTable.go
+++ b/pkg/utils/asciiTable.go
@@ -170,9 +170,7 @@ func calculateHeaderSize(header []ASCIITableHeader, dataRows reflect.Value, esca
 	}
 
 	avgLargeCol := (maxLineLength - (total - sumTooWide)) / numTooWide
-	if avgLargeCol < 5 {
-		avgLargeCol = 5
-	}
+	avgLargeCol = max(avgLargeCol, 5)
 	for i := range header {
 		if header[i].size > avgAvail {
 			header[i].size = avgLargeCol
@@ -248,9 +246,7 @@ func buildHeader(header []ASCIITableHeader) string {
 			padding = ":"
 		}
 		size := head.size
-		if size < 0 {
-			size = 0
-		}
+		size = max(size, 0)
 		fmt.Fprintf(&strBuilder, "|%s%s%s", padding, strings.Repeat("-", size), padding)
 	}
 	strBuilder.WriteString("|\n")

--- a/pkg/utils/asciiTable.go
+++ b/pkg/utils/asciiTable.go
@@ -170,6 +170,9 @@ func calculateHeaderSize(header []ASCIITableHeader, dataRows reflect.Value, esca
 	}
 
 	avgLargeCol := (maxLineLength - (total - sumTooWide)) / numTooWide
+	if avgLargeCol < 5 {
+		avgLargeCol = 5
+	}
 	for i := range header {
 		if header[i].size > avgAvail {
 			header[i].size = avgLargeCol
@@ -244,7 +247,11 @@ func buildHeader(header []ASCIITableHeader) string {
 		if head.Alignment == "centered" {
 			padding = ":"
 		}
-		fmt.Fprintf(&strBuilder, "|%s%s%s", padding, strings.Repeat("-", head.size), padding)
+		size := head.size
+		if size < 0 {
+			size = 0
+		}
+		fmt.Fprintf(&strBuilder, "|%s%s%s", padding, strings.Repeat("-", size), padding)
 	}
 	strBuilder.WriteString("|\n")
 


### PR DESCRIPTION
add "used %" to the attribute list as well, so thae entry can match against "[drive] used %" metrics that result from it. same with free , inodes_used and inodes_free"

set unit to % if the condition keyword string ends with " %" - this was forgotten in TransformMultipleKeywords.

add tests that use "used %" keyword to see if they match to the entry.