### PR TITLE
check_os_updates: allow yum to run as an unprivileged user

### DIFF
--- a/docs/checks/commands/check_os_updates.md
+++ b/docs/checks/commands/check_os_updates.md
@@ -28,6 +28,12 @@ If you only want to be notified about security related updates:
     check_os_updates warn=none crit='count_security > 0'
     CRITICAL - 1 security updates / 3 updates available. |'security'=1;;0;0 'updates'=3;0;;0
 
+On YUM/DNF systems, repository metadata is stored in a private cache owned by
+the SNClient service user. YUM/DNF refreshes missing or expired metadata without
+requiring root permissions. The **--update** option forces a metadata refresh.
+The check returns **UNKNOWN** if an enabled repository is unavailable, because
+otherwise an incomplete repository set could be reported as having no updates.
+
 ### Example using NRPE and Naemon
 
 Naemon Config

--- a/pkg/snclient/check_os_updates.go
+++ b/pkg/snclient/check_os_updates.go
@@ -64,6 +64,12 @@ If you only want to be notified about security related updates:
 
     check_os_updates warn=none crit='count_security > 0'
     CRITICAL - 1 security updates / 3 updates available. |'security'=1;;0;0 'updates'=3;0;;0
+
+On YUM/DNF systems, repository metadata is stored in a private cache owned by
+the SNClient service user. YUM/DNF refreshes missing or expired metadata without
+requiring root permissions. The **--update** option forces a metadata refresh.
+The check returns **UNKNOWN** if an enabled repository is unavailable, because
+otherwise an incomplete repository set could be reported as having no updates.
 	`,
 		exampleArgs: `warn='count > 0' crit='count_security > 0'`,
 	}

--- a/pkg/snclient/check_os_updates_linux.go
+++ b/pkg/snclient/check_os_updates_linux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -21,19 +22,23 @@ func (l *CheckOSUpdates) addOSBackends(ctx context.Context, check *CheckData) (i
 	err = nil
 
 	aptAdded, aptErr := l.addAPT(ctx, check)
-	if aptAdded {
+	if aptAdded && aptErr == nil {
 		addedCount++
 	}
 	if aptErr != nil {
-		err = fmt.Errorf("error when adding apt: %w", err)
+		err = fmt.Errorf("error when adding apt: %w", aptErr)
 	}
 
 	yumAdded, yumErr := l.addYUM(ctx, check)
-	if yumAdded {
+	if yumAdded && yumErr == nil {
 		addedCount++
 	}
 	if yumErr != nil {
-		err = fmt.Errorf("%w | error when adding yum: %w", err, yumErr)
+		if err == nil {
+			err = fmt.Errorf("error when adding yum: %w", yumErr)
+		} else {
+			err = fmt.Errorf("%w | error when adding yum: %w", err, yumErr)
+		}
 	}
 
 	return addedCount, err
@@ -115,17 +120,28 @@ func (l *CheckOSUpdates) addYUM(ctx context.Context, check *CheckData) (bool, er
 		return false, nil
 	}
 
-	// check requires root permission or capabilities
-	if os.Geteuid() != 0 && !HasCapabilities() {
-		return false, fmt.Errorf("check_os_updates requires root permissions or cap_setuid/cap_setgid")
+	cacheDir, err := l.yumCacheDir()
+	if err != nil {
+		return true, err
 	}
 
-	yumOpts := " -C"
+	yumOpts := fmt.Sprintf(
+		" --setopt=cachedir=%s --setopt='*.skip_if_unavailable=False'",
+		quoteShellArgument(cacheDir),
+	)
 	if l.update {
-		yumOpts = ""
+		// Expiring the private cache before the query forces a metadata refresh
+		// and works with both legacy Yum 3 and DNF.
+		output, stderr, exitCode, err := l.snc.execCommand(ctx, "yum"+yumOpts+" clean expire-cache -q", l.snc.getBuiltinCmdTimeout())
+		if err != nil {
+			return true, fmt.Errorf("yum cache expiration failed: %s\n%s", err.Error(), stderr)
+		}
+		if exitCode != 0 {
+			return true, fmt.Errorf("yum cache expiration failed: %s\n%s", output, stderr)
+		}
 	}
 
-	output, stderr, exitCode, err := l.snc.execCommandAsRoot(ctx, "yum check-update --security -q"+yumOpts, l.snc.getBuiltinCmdTimeout())
+	output, stderr, exitCode, err := l.snc.execCommand(ctx, "yum"+yumOpts+" check-update --security -q", l.snc.getBuiltinCmdTimeout())
 	if err != nil {
 		return true, fmt.Errorf("yum check-update failed: %s\n%s", err.Error(), stderr)
 	}
@@ -134,7 +150,7 @@ func (l *CheckOSUpdates) addYUM(ctx context.Context, check *CheckData) (bool, er
 	}
 	packageLookup := l.parseYUM(output, "1", check, nil)
 
-	output, stderr, exitCode, err = l.snc.execCommandAsRoot(ctx, "yum check-update -q"+yumOpts, l.snc.getBuiltinCmdTimeout())
+	output, stderr, exitCode, err = l.snc.execCommand(ctx, "yum"+yumOpts+" check-update -q", l.snc.getBuiltinCmdTimeout())
 	if err != nil {
 		return true, fmt.Errorf("yum check-update failed: %s\n%s", err.Error(), stderr)
 	}
@@ -144,6 +160,33 @@ func (l *CheckOSUpdates) addYUM(ctx context.Context, check *CheckData) (bool, er
 	l.parseYUM(output, "0", check, packageLookup)
 
 	return true, nil
+}
+
+func (l *CheckOSUpdates) yumCacheDir() (string, error) {
+	cacheDir := filepath.Join(l.snc.getCacheFolder(), "dnf")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create yum cache directory %s: %w", cacheDir, err)
+	}
+
+	info, err := os.Lstat(cacheDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect yum cache directory %s: %w", cacheDir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("yum cache path %s is not a directory", cacheDir)
+	}
+	if err := l.snc.checkFileOwner(cacheDir); err != nil {
+		return "", fmt.Errorf("invalid yum cache directory: %w", err)
+	}
+	if err := os.Chmod(cacheDir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to secure yum cache directory %s: %w", cacheDir, err)
+	}
+
+	return cacheDir, nil
+}
+
+func quoteShellArgument(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func (l *CheckOSUpdates) parseYUM(output, security string, check *CheckData, skipPackages map[string]bool) map[string]bool {

--- a/pkg/snclient/check_os_updates_linux.go
+++ b/pkg/snclient/check_os_updates_linux.go
@@ -132,9 +132,9 @@ func (l *CheckOSUpdates) addYUM(ctx context.Context, check *CheckData) (bool, er
 	if l.update {
 		// Expiring the private cache before the query forces a metadata refresh
 		// and works with both legacy Yum 3 and DNF.
-		output, stderr, exitCode, err := l.snc.execCommand(ctx, "yum"+yumOpts+" clean expire-cache -q", l.snc.getBuiltinCmdTimeout())
-		if err != nil {
-			return true, fmt.Errorf("yum cache expiration failed: %s\n%s", err.Error(), stderr)
+		output, stderr, exitCode, cacheErr := l.snc.execCommand(ctx, "yum"+yumOpts+" clean expire-cache -q", l.snc.getBuiltinCmdTimeout())
+		if cacheErr != nil {
+			return true, fmt.Errorf("yum cache expiration failed: %s\n%s", cacheErr.Error(), stderr)
 		}
 		if exitCode != 0 {
 			return true, fmt.Errorf("yum cache expiration failed: %s\n%s", output, stderr)

--- a/pkg/snclient/check_os_updates_linux_test.go
+++ b/pkg/snclient/check_os_updates_linux_test.go
@@ -1,10 +1,14 @@
 package snclient
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckAPTUpdates(t *testing.T) {
@@ -52,22 +56,117 @@ Inst steam-libs-i386:i386 [1:1.0.0.78] (1:1.0.0.79 Steam launcher:repo.steampowe
 func TestCheckYUMUpdates(t *testing.T) {
 	snc := StartTestAgent(t, "")
 
-	// mock yum command from output of: yum check-update -q -C
-	tmpPath := MockSystemUtilities(t, map[string]string{
-		"yum": `
-
+	// Mock yum command from output of: yum check-update -q
+	yumOutput := `
 bind-export-libs.x86_64    32:9.11.4-26.P2.el7_9.15       updates
 ca-certificates.noarch     2023.2.60_v7.0.306-72.el7_9    updates
 cronie.x86_64              1.4.11-25.el7_9                updates
 Obsoleting Packages
 grub2-tools.x86_64         1:2.06-70.el9_3.2.rocky.0.2    baseos
-    grub2-tools.x86_64     1:2.06-46.el9.rocky.0.1        @baseos`,
-		"yum_exit": "100",
-	})
-	defer os.RemoveAll(tmpPath)
+    grub2-tools.x86_64     1:2.06-46.el9.rocky.0.1        @baseos`
+	argsFile := mockYUMUtility(t, yumOutput, "", 100)
+	cacheRoot := filepath.Join(t.TempDir(), "cache root's")
+	t.Setenv("CACHE_DIRECTORY", cacheRoot)
+
 	res := snc.RunCheck("check_os_updates", []string{"--system=yum"})
 	assert.Equalf(t, CheckExitCritical, res.State, "state Critical")
 	assert.Containsf(t, string(res.BuildPluginOutput()), "CRITICAL - 3 security updates / 0 updates available. |'security'=3;;0;0 'updates'=0;0;;0", "output matches")
 
+	argsRaw, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := strings.Split(strings.TrimSpace(string(argsRaw)), "\n")
+	require.Len(t, args, 2)
+
+	cacheDir := filepath.Join(cacheRoot, "dnf")
+	requiredOpts := "<--setopt=cachedir=" + cacheDir + ">" +
+		"<--setopt=*.skip_if_unavailable=False>"
+	assert.Equal(t, requiredOpts+"<check-update><--security><-q>", args[0])
+	assert.Equal(t, requiredOpts+"<check-update><-q>", args[1])
+	assert.NotContains(t, string(argsRaw), "<-C>")
+	assert.NotContains(t, string(argsRaw), "<--refresh>")
+
+	cacheInfo, err := os.Stat(cacheDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), cacheInfo.Mode().Perm())
+
 	StopTestAgent(t, snc)
+}
+
+func TestCheckYUMUpdateUsesLegacyCompatibleCacheExpiration(t *testing.T) {
+	snc := StartTestAgent(t, "")
+	argsFile := mockYUMUtility(t, "", "", 0)
+	cacheRoot := t.TempDir()
+	t.Setenv("CACHE_DIRECTORY", cacheRoot)
+
+	res := snc.RunCheck("check_os_updates", []string{"--system=yum", "--update"})
+	assert.Equal(t, CheckExitOK, res.State)
+
+	argsRaw, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := strings.Split(strings.TrimSpace(string(argsRaw)), "\n")
+	require.Len(t, args, 3)
+
+	cacheDir := filepath.Join(cacheRoot, "dnf")
+	requiredOpts := "<--setopt=cachedir=" + cacheDir + ">" +
+		"<--setopt=*.skip_if_unavailable=False>"
+	assert.Equal(t, requiredOpts+"<clean><expire-cache><-q>", args[0])
+	assert.Equal(t, requiredOpts+"<check-update><--security><-q>", args[1])
+	assert.Equal(t, requiredOpts+"<check-update><-q>", args[2])
+	assert.NotContains(t, string(argsRaw), "<--refresh>")
+
+	StopTestAgent(t, snc)
+}
+
+func TestCheckYUMUnavailableRepositoriesFail(t *testing.T) {
+	snc := StartTestAgent(t, "")
+	mockYUMUtility(t, "", "Failed to download metadata for repo 'baseos'", 1)
+	t.Setenv("CACHE_DIRECTORY", t.TempDir())
+
+	res := snc.RunCheck("check_os_updates", []string{"--system=yum"})
+	assert.Equal(t, CheckExitUnknown, res.State)
+	assert.Contains(t, string(res.BuildPluginOutput()), "yum check-update failed")
+	assert.Contains(t, string(res.BuildPluginOutput()), "Failed to download metadata for repo 'baseos'")
+
+	StopTestAgent(t, snc)
+}
+
+func TestCheckYUMRejectsSymlinkedCache(t *testing.T) {
+	snc := StartTestAgent(t, "")
+	mockYUMUtility(t, "", "", 0)
+	cacheRoot := t.TempDir()
+	t.Setenv("CACHE_DIRECTORY", cacheRoot)
+	require.NoError(t, os.Symlink(t.TempDir(), filepath.Join(cacheRoot, "dnf")))
+
+	res := snc.RunCheck("check_os_updates", []string{"--system=yum"})
+	assert.Equal(t, CheckExitUnknown, res.State)
+	assert.Contains(t, string(res.BuildPluginOutput()), "yum cache path")
+	assert.Contains(t, string(res.BuildPluginOutput()), "is not a directory")
+
+	StopTestAgent(t, snc)
+}
+
+func mockYUMUtility(t *testing.T, stdout, stderr string, exitCode int) string {
+	t.Helper()
+
+	tmpPath := MockSystemUtilities(t, map[string]string{"yum": ""})
+	argsFile := filepath.Join(t.TempDir(), "yum-args")
+	t.Setenv("YUM_ARGS_FILE", argsFile)
+
+	script := fmt.Sprintf(`#!/bin/sh
+for arg do
+    printf '<%%s>' "$arg" >> "$YUM_ARGS_FILE"
+done
+printf '\n' >> "$YUM_ARGS_FILE"
+cat <<'YUM_STDOUT'
+%s
+YUM_STDOUT
+cat >&2 <<'YUM_STDERR'
+%s
+YUM_STDERR
+exit %d
+`, stdout, stderr, exitCode)
+	err := os.WriteFile(filepath.Join(tmpPath, "yum"), []byte(script), 0o700)
+	require.NoError(t, err)
+
+	return argsFile
 }

--- a/pkg/snclient/check_os_updates_linux_test.go
+++ b/pkg/snclient/check_os_updates_linux_test.go
@@ -165,7 +165,10 @@ cat >&2 <<'YUM_STDERR'
 YUM_STDERR
 exit %d
 `, stdout, stderr, exitCode)
-	err := os.WriteFile(filepath.Join(tmpPath, "yum"), []byte(script), 0o700)
+	yumPath := filepath.Join(tmpPath, "yum")
+	err := os.WriteFile(yumPath, []byte(script), 0o600)
+	require.NoError(t, err)
+	err = os.Chmod(yumPath, 0o700)
 	require.NoError(t, err)
 
 	return argsFile


### PR DESCRIPTION
Issue #434 showed that yum could report no updates when the check ran as the snclient service user. Commit
e57cb69cc472834d5c1c546d4538351755aa508d addressed this by requiring root permissions or capabilities and executing yum with elevated privileges. This change proposes using a private metadata cache owned by the service user, allowing Yum and DNF to run without elevated privileges.

- Configure Yum and DNF to use the private cache.
- Expire cached metadata when --update is requested.
- Return UNKNOWN when an enabled repository is unavailable.
- Validate ownership and permissions of the cache directory.
- Document the behavior and extend the Yum tests.

Tested on Rocky Linux 9 and CentOS 7

Refs: #434